### PR TITLE
fix(skills): repair ux-writing frontmatter, add document responsibility and progressive disclosure rules

### DIFF
--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -123,7 +123,10 @@ applied to prose.
   hashes, object and migration counts, expiry dates, and "currently live /
   not yet shipped" claims all change without anyone re-reading the page that
   repeats them. Those belong in a changelog, in git history, or on the
-  release ticket, where carrying a date is the point. *Counter-example: a
+  release ticket, where carrying a date is the point. The rule forbids the
+  hand-maintained second copy, not the table: when a page genuinely has to
+  show current values, generate it from the authoritative source at build
+  time so it cannot drift silently. *Counter-example: a
   runbook opened with "production currently runs 2.3.1"; four releases later
   an on-call engineer trusted the line and worked through the wrong
   version's changelog.*
@@ -134,7 +137,12 @@ applied to prose.
   data key, or heading. "See the source", a repo-root link, or a directory
   leaves the reader to re-derive what the sentence promised. If no single
   symbol owns the fact, that is a code problem surfacing as a doc problem;
-  fix the boundary instead of papering over it with a copied table.
+  fix the boundary instead of papering over it with a copied table. A
+  directory is a fair target in two cases only: the fact emerges from an
+  ordered set with no single-file truth (migrations replayed in sequence),
+  or the directory is a catalog some loader enumerates (locales, plugins,
+  maps). Both still owe a searchable selection key — the naming convention,
+  the loader function, the object name.
   *Counter-example: "protocol versions are defined in the networking layer"
   sent every reader grepping six files, and became a link to
   `PROTOCOL_VERSION` in `net/constants.py`.*

--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux-writing
-description: Judgment rules for user-facing text and documentation: CLI/tool output, status and diagnostic displays, error messages, help text, README and docs structure, keeping long-lived docs free of values that go stale, and keeping copy in sync with behavior. Use when writing or changing any user-visible string, when adding or restructuring documentation, when a doc is about to record a version, a deployment state, or a value the code already owns, or when reviewing a diff that touches copy or docs.
+description: Judgment rules for user-facing text and documentation: CLI/tool output, status and diagnostic displays, error messages, help text, README and docs structure, keeping long-lived docs free of values that go stale, and keeping copy in sync with behavior. Use when writing or changing any user-visible string, when adding or restructuring documentation, when deciding which document owns a fact or where a new page or section belongs, when a doc is about to record a version, a deployment state, or a value the code already owns, or when reviewing a diff that touches copy or docs.
 ---
 
 # UX Writing & Docs
@@ -56,6 +56,18 @@ exception purely to suppress a traceback, keep the message intact.
 
 ## Documentation
 
+- **Each document has one responsibility, and it decides what belongs.** A
+  page is a durable contract, a proposal, an investigation, a TODO, a dated
+  work order, or a runbook — one of them, not several. Naming that first is
+  what makes a canonical home decidable: a fact lives on the page whose job
+  it is, and every other surface reaches it through a single specific link
+  instead of a partial retelling on each page that happens to touch it. When
+  two pages both claim to be the detailed spec, the broader responsibility
+  keeps the shared rules and the narrower keeps only what its own surface
+  adds. *Counter-example: an implementation plan stayed the de-facto spec
+  after shipping, so the rules lived half there and half in the architecture
+  doc; folding the stable rules into the contract and leaving the sequence in
+  git history left one page to trust.*
 - **One canonical home per fact.** Details that change together (field
   lists, precedence chains, supported values) live in exactly one document;
   every other mention links to it. Legitimate copies: artifacts distributed

--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -90,6 +90,18 @@ exception purely to suppress a traceback, keep the message intact.
   don't accumulate feature bullets; quick-starts don't explain architecture.
   A README stays lean and links into the docs; detail accumulating there
   usually means it left its canonical home.
+- **Order a page by what the reader needs first, and split when it stops
+  being one task.** Open with scope and the authoritative entry points, then
+  the common rules and the main path, and only then exceptions, recovery,
+  and change checks. An overview layer summarizes stable semantics and links
+  down; it does not carry field tables, full payloads, or current numbers to
+  buy self-containment. When a page starts demanding that the reader
+  understand several unrelated tasks, or whole chapters serve only two
+  maintainers, that is the signal to split it — and the split leaves behind
+  one line of purpose plus the link, never a second copy of the fact.
+  *Counter-example: a getting-started page opened with the full option
+  reference, so the three commands a first-time reader needed sat two
+  screens below it.*
 - **Reminders name the most-forgotten item only.** A guideline that
   enumerates every artifact reads as noise and gets skipped whole. "Update
   whichever docs the change affects; the bundled skill is the easiest to

--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux-writing
-description: Judgment rules for user-facing text and documentation: CLI/tool output, status and diagnostic displays, error messages, help text, README and docs structure, keeping long-lived docs free of values that go stale, and keeping copy in sync with behavior. Use when writing or changing any user-visible string, when adding or restructuring documentation, when deciding which document owns a fact or where a new page or section belongs, when a doc is about to record a version, a deployment state, or a value the code already owns, or when reviewing a diff that touches copy or docs.
+description: "Judgment rules for user-facing text and documentation: CLI/tool output, status and diagnostic displays, error messages, help text, README and docs structure, keeping long-lived docs free of values that go stale, and keeping copy in sync with behavior. Use when writing or changing any user-visible string, when adding or restructuring documentation, when deciding which document owns a fact or where a new page or section belongs, when a doc is about to record a version, a deployment state, or a value the code already owns, or when reviewing a diff that touches copy or docs."
 ---
 
 # UX Writing & Docs


### PR DESCRIPTION
## 修复：frontmatter 无法解析（优先看这条）

`skills/ux-writing/SKILL.md` 的 `description` 是未加引号的 YAML plain scalar，值里含 `documentation: CLI/tool output` 这个冒号加空格。YAML 把 plain scalar 中的 `: ` 当作 mapping 分隔符，于是解析在第 3 行第 67 列失败：

```
Error in user YAML: (<unknown>): mapping values are not allowed in this context at line 2 column 67
```

结果是整个 skill 加载不了。该缺陷此前已在 main 上，非本次改动引入。修法是把值用双引号包裹，文本一字未改。

验证（PyYAML）：

```
$ python -c "import yaml; ..."
OK   skills/ux-writing/SKILL.md | name = ux-writing | desc len = 577
OK   skills/talk-like-scarletkc/SKILL.md | name = talk-like-scarletkc | desc len = 215
```

`talk-like-scarletkc` 一直正常，因为它的 description 用的是全角冒号。

## 规则改动

`ux-writing` 已经有 "One canonical home per fact"，但它只回答"事实该只写一份"，没有回答"该写在哪一份文档里"、"一份文档里怎么排"。实践中文档失控通常发生在这两层：一份文档同时承担计划、规范和运维记录，同一套规则被拆散在多处；或者一份文档内部把完整参考表放在最前面，读者要翻两屏才看到自己要做的事。

参考 `crown-marshal/docs/documentation-guidelines.md` 的文档类型（§5）与逐渐披露（§7）补上这两条，并借这次核对补齐上一版 stale-facts 规则漏掉的两处例外。

### Documentation 新增两条

**Each document has one responsibility, and it decides what belongs.**

- 文档只取一种主类型：durable contract / proposal / investigation / TODO / dated work order / runbook；
- 先定职责才能判定 canonical home，其他表面用唯一的具体链接指过去，而不是各自零散重述一部分；
- 两份文档都自称详细规范时，上层职责保留共有规则，下层只留本表面特有的内容；
- counter-example 用"实施方案上线后继续充当规范"这一常见失败。

**Order a page by what the reader needs first, and split when it stops being one task.**

- 页内顺序：范围与权威入口 → 常用规则与主流程 → 异常、恢复、变更检查；
- 概览层链接下钻，不靠复制字段表、完整载荷或当前数值来换自包含；
- 一份文档开始要求读者理解多个独立任务时即为拆分信号，拆分后只留一句用途加链接，不制造第二份副本。

### Facts that go stale 补齐两处例外

两条规则各自差一句话才可执行：

- **A pointer names a symbol, not a repository.** 原文说目录链接不够具体，但没给例外，照此执行的读者遇到 migration 这类事实会发现无处可链。补上两种正当情形：事实由有序集合共同形成而无单文件真值，或目录本身是加载器枚举的目录；两种情形仍须给出可搜索的选择键。
- **Never snapshot a value that moves faster than the doc.** 原文读起来像禁止出现当前数值，对"确实需要一张当前参数表"没有答案。明确禁止的是手工维护的第二份副本，需要展示当前值时由构建期从权威源生成。

### 其他

同步扩写 `description` 的触发场景：决定某个事实归哪份文档、新页面或新章节该放哪里。

未采纳参考文件中的领域权威矩阵（§5.1）和目录分类（§6、§7 前半的四层结构）：前者是某个仓库把裁决结果物化成的表，后者规定了具体目录分层，都属于项目特有，通用 skill 给出裁决依据即可。

## 验证

- frontmatter 解析：见上方 PyYAML 输出，两个 skill 均通过；
- 逐节核对参考文件 §1–§7，除上述有意不取的两处外均已落入 skill；
- `README.md` 的 skill 表格描述仍成立（新增两条均属 "docs structure"），无需改写；
- `AGENTS.md` 指向 `ux-writing` 的引用未涉及具体条目，无失效链接；
- 插入位置符合技能自身的 "Insertion respects adjacency"：职责条置于 "One canonical home per fact" 之前，构成从文档职责到事实归属的顺序；逐渐披露条紧接 "Every README section has one job"，承接该条结尾"细节堆积说明它离开了 canonical home"；两处例外写在各自条目的规则句之后、counter-example 之前，未打断既有段落与其后续说明。