### PR TITLE
chore(skills): validate catalog and document installers

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,33 @@
+name: Validate skills
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Test catalog generator
+        run: python -m unittest discover -s tests -v
+
+      - name: Check README skill catalog
+        run: python scripts/update_readme_skills.py --check
+
+      - name: Validate Agent Skills
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh skill publish --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -14,17 +14,58 @@ and anything else that reads `AGENTS.md` or the
 
 ## Skills
 
-| Skill | Description |
-|-------|-------------|
-| [talk-like-scarletkc](skills/talk-like-scarletkc/SKILL.md) | Write, rewrite, polish, and translate text in ScarletKC's natural voice (tweets, comments, chat messages, technical opinions, GitHub text, formal correspondence) instead of generic AI copy |
-| [ux-writing](skills/ux-writing/SKILL.md) | Judgment rules for user-facing text and documentation: CLI output, diagnostics, error messages, docs structure, keeping long-lived docs free of values that go stale, and keeping copy in sync with behavior |
+Each summary is generated from the skill's own metadata. Open its `SKILL.md`
+for the complete activation description and instructions.
 
-## Install a skill
+<!-- skills:start -->
+| Skill | Summary |
+|-------|---------|
+| [talk-like-scarletkc](skills/talk-like-scarletkc/SKILL.md) | Write and translate in ScarletKC's natural voice without generic AI phrasing. |
+| [ux-writing](skills/ux-writing/SKILL.md) | Review user-facing copy and documentation for clarity, consistency, and facts that do not go stale. |
+<!-- skills:end -->
 
-Copy a skill directory into the agent's global skills directory:
+## Install skills
 
-- Claude Code: `~/.claude/skills/<name>/`
-- Codex CLI: `~/.codex/skills/<name>/`
+Send this prompt to your coding agent:
+
+> Install skills from https://github.com/FogMoe/agents. Show me the available
+> skills and let me choose which ones to install.
+
+You can also use either CLI directly. Both installers let you choose individual
+skills. Replace `codex` with another supported agent, such as `claude-code`,
+when needed.
+
+### GitHub CLI
+
+Browse the repository and install a skill for the current user:
+
+```sh
+gh skill install FogMoe/agents --agent codex --scope user
+```
+
+For a non-interactive installation, provide the skill name:
+
+```sh
+gh skill install FogMoe/agents <skill> --agent codex --scope user
+```
+
+Update installed skills with `gh skill update --all`.
+
+### skills CLI
+
+Browse the repository and choose skills and agents interactively:
+
+```sh
+npx skills add FogMoe/agents -g
+```
+
+For a non-interactive installation, provide the skill and agent:
+
+```sh
+npx skills add FogMoe/agents --skill <skill> --agent codex -g -y
+```
+
+Update global skills with `npx skills update -g -y`.
 
 ## License
 

--- a/scripts/update_readme_skills.py
+++ b/scripts/update_readme_skills.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Generate the README skill catalog from SKILL.md metadata."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+START_MARKER = "<!-- skills:start -->"
+END_MARKER = "<!-- skills:end -->"
+SUMMARY_KEY = "fogmoe-summary"
+
+
+class CatalogError(ValueError):
+    """Raised when the skill catalog source is invalid."""
+
+
+@dataclass(frozen=True)
+class Skill:
+    name: str
+    summary: str
+    readme_path: str
+
+
+def _parse_scalar(value: str, *, path: Path, field: str) -> str:
+    value = value.strip()
+    if not value:
+        raise CatalogError(f"{path}: {field} must not be empty")
+    if value.startswith('"'):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise CatalogError(f"{path}: invalid quoted {field}: {exc.msg}") from exc
+        if not isinstance(parsed, str) or not parsed:
+            raise CatalogError(f"{path}: {field} must be a non-empty string")
+        return parsed
+    if value.startswith("'"):
+        if len(value) < 2 or not value.endswith("'"):
+            raise CatalogError(f"{path}: invalid quoted {field}")
+        return value[1:-1].replace("''", "'")
+    return value
+
+
+def _frontmatter_lines(path: Path) -> list[str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0] != "---":
+        raise CatalogError(f"{path}: missing opening frontmatter delimiter")
+    try:
+        end = lines.index("---", 1)
+    except ValueError as exc:
+        raise CatalogError(f"{path}: missing closing frontmatter delimiter") from exc
+    return lines[1:end]
+
+
+def _read_skill(path: Path, repo_root: Path) -> Skill:
+    name: str | None = None
+    summary: str | None = None
+    in_metadata = False
+
+    for line in _frontmatter_lines(path):
+        top_level = re.fullmatch(r"([a-zA-Z0-9_-]+):(?:\s*(.*))?", line)
+        if top_level:
+            key, value = top_level.groups()
+            in_metadata = key == "metadata"
+            if key == "name":
+                name = _parse_scalar(value or "", path=path, field="name")
+            continue
+
+        if in_metadata:
+            metadata_item = re.fullmatch(r"\s{2}([a-zA-Z0-9_-]+):\s*(.*)", line)
+            if metadata_item and metadata_item.group(1) == SUMMARY_KEY:
+                summary = _parse_scalar(
+                    metadata_item.group(2), path=path, field=f"metadata.{SUMMARY_KEY}"
+                )
+
+    if name is None:
+        raise CatalogError(f"{path}: missing name")
+    if summary is None:
+        raise CatalogError(f"{path}: missing metadata.{SUMMARY_KEY}")
+    if name != path.parent.name:
+        raise CatalogError(
+            f"{path}: skill name {name!r} does not match directory {path.parent.name!r}"
+        )
+
+    readme_path = path.relative_to(repo_root).as_posix()
+    return Skill(name=name, summary=summary, readme_path=readme_path)
+
+
+def load_skills(repo_root: Path) -> list[Skill]:
+    skill_paths = sorted((repo_root / "skills").rglob("SKILL.md"))
+    if not skill_paths:
+        raise CatalogError(f"{repo_root / 'skills'}: no SKILL.md files found")
+
+    skills = [_read_skill(path, repo_root) for path in skill_paths]
+    names = [skill.name for skill in skills]
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        raise CatalogError(f"duplicate skill names: {', '.join(duplicates)}")
+    return sorted(skills, key=lambda skill: skill.name)
+
+
+def _escape_table_cell(value: str) -> str:
+    return value.replace("|", r"\|").replace("\r", " ").replace("\n", " ")
+
+
+def render_catalog(skills: list[Skill], newline: str = "\n") -> str:
+    lines = [
+        START_MARKER,
+        "| Skill | Summary |",
+        "|-------|---------|",
+    ]
+    lines.extend(
+        f"| [{skill.name}]({skill.readme_path}) | {_escape_table_cell(skill.summary)} |"
+        for skill in skills
+    )
+    lines.append(END_MARKER)
+    return newline.join(lines)
+
+
+def updated_readme(repo_root: Path) -> tuple[str, str]:
+    readme_path = repo_root / "README.md"
+    current = readme_path.read_bytes().decode("utf-8")
+    newline = "\r\n" if "\r\n" in current else "\n"
+    pattern = re.compile(
+        rf"{re.escape(START_MARKER)}.*?{re.escape(END_MARKER)}", re.DOTALL
+    )
+    if len(pattern.findall(current)) != 1:
+        raise CatalogError(
+            f"{readme_path}: expected exactly one skill catalog marker pair"
+        )
+    generated = pattern.sub(render_catalog(load_skills(repo_root), newline), current)
+    return current, generated
+
+
+def update_readme(repo_root: Path, *, check: bool) -> bool:
+    current, generated = updated_readme(repo_root)
+    if current.replace("\r\n", "\n") == generated.replace("\r\n", "\n"):
+        return False
+    if check:
+        diff = difflib.unified_diff(
+            current.splitlines(),
+            generated.splitlines(),
+            fromfile="README.md",
+            tofile="README.md (generated)",
+            lineterm="",
+        )
+        print("\n".join(diff), file=sys.stderr)
+        print(
+            "README skill catalog is stale; run "
+            "`python scripts/update_readme_skills.py`.",
+            file=sys.stderr,
+        )
+        return True
+
+    (repo_root / "README.md").write_bytes(generated.encode("utf-8"))
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check", action="store_true", help="fail instead of updating a stale catalog"
+    )
+    args = parser.parse_args(argv)
+    repo_root = Path(__file__).resolve().parent.parent
+    try:
+        changed = update_readme(repo_root, check=args.check)
+    except (CatalogError, OSError, UnicodeError) as exc:
+        print(exc, file=sys.stderr)
+        return 2
+    return 1 if args.check and changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/talk-like-scarletkc/SKILL.md
+++ b/skills/talk-like-scarletkc/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: talk-like-scarletkc
 description: 按 ScarletKC 本人的自然表达习惯撰写、改写、润色和翻译文本，覆盖推文、微博、评论、聊天消息、技术观点、项目介绍、GitHub 文本（README、issue、PR、发布说明）和正式通信。当用户要求用自己的口吻写东西、把 AI 腔文字改自然、发推、回评论、点评模型或开发工具、写项目公告、写礼貌但直接的客服或正式邮件，或要求翻译时保留语气和立场，都使用本 skill，即使用户没有点名 ScarletKC 或提出风格要求。
+license: Apache-2.0
+metadata:
+  fogmoe-summary: "Write and translate in ScarletKC's natural voice without generic AI phrasing."
 ---
 
 # Talk Like ScarletKC

--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: ux-writing
 description: "Judgment rules for user-facing text and documentation: CLI/tool output, status and diagnostic displays, error messages, help text, README and docs structure, keeping long-lived docs free of values that go stale, and keeping copy in sync with behavior. Use when writing or changing any user-visible string, when adding or restructuring documentation, when deciding which document owns a fact or where a new page or section belongs, when a doc is about to record a version, a deployment state, or a value the code already owns, or when reviewing a diff that touches copy or docs."
+license: Apache-2.0
+metadata:
+  fogmoe-summary: "Review user-facing copy and documentation for clarity, consistency, and facts that do not go stale."
 ---
 
 # UX Writing & Docs

--- a/tests/test_update_readme_skills.py
+++ b/tests/test_update_readme_skills.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+from scripts.update_readme_skills import CatalogError, update_readme
+
+
+README_TEMPLATE = """# Skills
+
+<!-- skills:start -->
+stale
+<!-- skills:end -->
+"""
+
+
+def write_skill(root: Path, name: str, summary: str | None) -> None:
+    metadata = "" if summary is None else f'\nmetadata:\n  fogmoe-summary: "{summary}"'
+    path = root / "skills" / name / "SKILL.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        f"---\nname: {name}\ndescription: Test skill.{metadata}\n---\n",
+        encoding="utf-8",
+    )
+
+
+class UpdateReadmeSkillsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        (self.root / "README.md").write_text(README_TEMPLATE, encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_updates_catalog_from_metadata_in_name_order(self) -> None:
+        write_skill(self.root, "zulu", "Last skill.")
+        write_skill(self.root, "alpha", "First skill.")
+
+        self.assertTrue(update_readme(self.root, check=False))
+
+        readme = (self.root / "README.md").read_text(encoding="utf-8")
+        self.assertLess(readme.index("[alpha]"), readme.index("[zulu]"))
+        self.assertIn("| [alpha](skills/alpha/SKILL.md) | First skill. |", readme)
+        self.assertFalse(update_readme(self.root, check=True))
+
+    def test_check_reports_stale_catalog_without_writing(self) -> None:
+        write_skill(self.root, "alpha", "First skill.")
+
+        with redirect_stderr(io.StringIO()):
+            self.assertTrue(update_readme(self.root, check=True))
+        self.assertEqual(
+            (self.root / "README.md").read_text(encoding="utf-8"), README_TEMPLATE
+        )
+
+    def test_check_ignores_line_ending_differences(self) -> None:
+        write_skill(self.root, "alpha", "First skill.")
+        update_readme(self.root, check=False)
+        readme_path = self.root / "README.md"
+        content = readme_path.read_bytes().replace(b"\r\n", b"\n")
+        readme_path.write_bytes(content.replace(b"\n", b"\r\n"))
+
+        self.assertFalse(update_readme(self.root, check=True))
+
+    def test_rejects_skill_without_summary(self) -> None:
+        write_skill(self.root, "alpha", None)
+
+        with self.assertRaisesRegex(CatalogError, "missing metadata.fogmoe-summary"):
+            update_readme(self.root, check=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- generate the README skill catalog from a short summary stored in each `SKILL.md`
- document agent-directed installation plus `gh skill` and `npx skills` workflows
- validate skill metadata and catalog synchronization in GitHub Actions
- ignore Python bytecode and cover the catalog generator with unit tests

## Why

The hand-maintained README catalog could drift when skills were added or changed. Keeping the short user-facing summary with each skill gives the catalog one source of truth, while the full `description` remains focused on agent activation.

## Impact

Contributors now add `metadata.fogmoe-summary` to each skill and regenerate the README with `python scripts/update_readme_skills.py`. CI fails when the catalog is stale or the skills do not satisfy the Agent Skills specification.

## Validation

- `python -m unittest discover -s tests -v` - 4 tests passed
- `python scripts/update_readme_skills.py --check`
- `gh skill publish --dry-run`
- `git diff --check`
