### PR TITLE
feat(skills): add worktree-pr and marketing-copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ for the complete activation description and instructions.
 <!-- skills:start -->
 | Skill | Summary |
 |-------|---------|
+| [marketing-copy](skills/marketing-copy/SKILL.md) | Write outbound promo copy that stays truthful, discloses only what may be public, and earns attention without hype. |
 | [talk-like-scarletkc](skills/talk-like-scarletkc/SKILL.md) | Write and translate in scarletkc's natural voice without generic AI phrasing. |
 | [ux-writing](skills/ux-writing/SKILL.md) | Review user-facing copy and documentation for clarity, consistency, and facts that do not go stale. |
+| [worktree-pr](skills/worktree-pr/SKILL.md) | Run a task in its own worktree: branch from the integration branch, compare against the baseline, land through a PR. |
 <!-- skills:end -->
 
 ## Install skills

--- a/skills/marketing-copy/SKILL.md
+++ b/skills/marketing-copy/SKILL.md
@@ -57,21 +57,24 @@ Never invent a metric, a benchmark, a user count, a review quote, or a
 comparison against a named competitor. When the honest version is thin, that
 is information about the release, not a prompt to inflate it.
 
-## Earning the read
+## Writing for someone who has never seen it
 
-- **The opening line delivers the news.** It is the only part most people
-  see. A headline that describes the category ("a new update is here")
-  spends the reader's only guaranteed attention on nothing.
-- **Say what it is before why it matters.** A reader who cannot tell what the
-  product does will not care that it improved.
-- **One post, one thing to take away.** Everything else is support, and a
-  post arguing several unrelated points lands none of them.
-- **Ask for one action.** Name it specifically and put it where the reader
-  arrives at it. Two competing asks split the response.
-- **Skip the promotional register.** Revolutionary, seamless, game-changing,
-  and unleash read as filler because they appear in every launch post
-  regardless of what shipped. So do manufactured urgency and invented
-  scarcity.
+Say what the thing is before saying why it got better. A reader who cannot
+tell what the product does has no way to care that it improved, and an
+update post aimed at existing users reads as noise to everyone else. When a
+post has to serve both audiences, the identifying sentence costs one line
+and buys the rest.
+
+Revolutionary, seamless, game-changing, and unleash have stopped carrying
+meaning in this genre: they appear in every launch post regardless of what
+shipped, so a reader skips them to look for the specifics underneath. Write
+the specifics instead. Manufactured urgency and invented scarcity fail the
+same way, and cost more when the deadline turns out to be arbitrary.
+
+A post may legitimately carry several asks, since a launch often wants the
+wishlist, the community, and the download at once. Order them by what this
+particular reader can act on now, and let each one be findable rather than
+competing for the same sentence.
 
 ## Naming across languages
 

--- a/skills/marketing-copy/SKILL.md
+++ b/skills/marketing-copy/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: marketing-copy
+description: "Write outbound promotional copy for a product or project: launch and update posts for community platforms and social media, store page descriptions and short blurbs, landing page headlines and calls to action, press-style announcements, and the naming of a product for another language or market. Covers what may be disclosed publicly, keeping claims traceable to shipped changes, and writing a headline that carries information instead of hype. Use when drafting or revising anything aimed at people who do not use the product yet, and when deciding whether a link, key, price, or unreleased detail can appear in public copy."
+license: Apache-2.0
+metadata:
+  author: scarletkc
+  fogmoe-source: https://github.com/FogMoe/agents
+  fogmoe-summary: "Write outbound promo copy that stays truthful, discloses only what may be public, and earns attention without hype."
+---
+
+# Marketing Copy
+
+Outbound copy reaches people who have no product context and no reason to
+finish reading. It is also the surface where a disclosure mistake is
+permanent: a post can be deleted, a screenshot of it cannot. Both facts push
+the same way, toward concrete claims a reader can check.
+
+This covers copy aimed outward. Product-internal strings and documentation
+follow [`ux-writing`](../ux-writing/SKILL.md); matching the author's personal
+voice is [`talk-like-scarletkc`](../talk-like-scarletkc/SKILL.md).
+
+## Disclosure comes first
+
+Decide what may be public before writing, because the draft is where a leak
+gets normalized.
+
+- **Keys, invite codes, and credentials are not copy.** Anything that grants
+  access belongs in the channel that distributes it under its own terms,
+  never inline in a public post, and never pasted into a draft "to be removed
+  later".
+- **An unreleased or unlisted URL stays unlisted.** A link that has not been
+  announced is not published just because it resolves. The same applies to
+  endpoints, staging hosts, and pages reachable only by those already told.
+- **Platform rules bind the copy, not just the account.** Each destination
+  has its own limits on what may be promoted, linked, priced, or given
+  away, and they differ between platforms carrying the same post. When a
+  rule makes a detail unpostable, drop the detail; hinting at it obliquely
+  to stay within the letter of the rule is the same violation with worse
+  writing.
+- **Unshipped work is not a feature.** Roadmap items, planned platforms, and
+  anything gated behind review get described as what they are, or left out.
+  Announcing a date creates an obligation the copy cannot see.
+
+When a constraint blocks a detail the requester wanted to include, say which
+detail and why, and let them decide, rather than quietly dropping it or
+quietly keeping it.
+
+## Claims stay traceable
+
+Take substance from what actually shipped: the changelog, the commit range,
+the release notes. Every concrete claim should trace to one of those, and
+specifics beat adjectives at the same length. A number, a mechanism, or a
+before-and-after carries conviction that "greatly improved" cannot, and it
+also survives a reader who checks.
+
+Never invent a metric, a benchmark, a user count, a review quote, or a
+comparison against a named competitor. When the honest version is thin, that
+is information about the release, not a prompt to inflate it.
+
+## Earning the read
+
+- **The opening line delivers the news.** It is the only part most people
+  see. A headline that describes the category ("a new update is here")
+  spends the reader's only guaranteed attention on nothing.
+- **Say what it is before why it matters.** A reader who cannot tell what the
+  product does will not care that it improved.
+- **One post, one thing to take away.** Everything else is support, and a
+  post arguing several unrelated points lands none of them.
+- **Ask for one action.** Name it specifically and put it where the reader
+  arrives at it. Two competing asks split the response.
+- **Skip the promotional register.** Revolutionary, seamless, game-changing,
+  and unleash read as filler because they appear in every launch post
+  regardless of what shipped. So do manufactured urgency and invented
+  scarcity.
+
+## Naming across languages
+
+A product name rendered for another market is a naming decision, not a
+translation. Check that the candidate is pronounceable and memorable for
+that audience, carries no unintended meaning, and does not collide with an
+existing product in the same category. Prefer a name the audience can
+search, and once a rendering has shipped anywhere public, keep it stable. A
+second name for the same product splits every search result and every
+conversation about it.

--- a/skills/worktree-pr/SKILL.md
+++ b/skills/worktree-pr/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: worktree-pr
+description: "Decide whether a task deserves its own git worktree, then run it end to end: branch from the integration branch rather than the current tree, keep the main working copy untouched while the task runs, compare the result against the untouched baseline before declaring it done, and land it through a pull request instead of merging. Use when a request says to do the work in a new worktree or branch, when a change is large or risky enough that the main tree should stay usable, when several tasks need to run in parallel on one repository, when a result has to be diffed against current behavior, and when deciding where screenshots, builds, and other artifacts produced in a worktree should end up."
+license: Apache-2.0
+metadata:
+  author: scarletkc
+  fogmoe-source: https://github.com/FogMoe/agents
+  fogmoe-summary: "Run a task in its own worktree: branch from the integration branch, compare against the baseline, land through a PR."
+---
+
+# Worktree & PR
+
+A worktree buys two things: the main working copy stays usable while the task
+runs, and the untouched copy remains available as a baseline to compare
+against. Both are worth real setup cost, and neither applies to every change.
+
+## Deciding
+
+Open a worktree when at least one holds: the task is large enough that a
+half-finished state would block other work, several tasks need to progress on
+the same repository at once, the result has to be compared against current
+behavior, or the change is risky enough that abandoning it should cost
+nothing.
+
+Skip it when the change is small, self-contained, and reviewable in one pass.
+Setting up an isolated copy for a typo fix or a one-line config edit costs
+more than it saves, and the extra branch, directory, and PR are all overhead
+that someone pays later. When the requester says to work directly on the
+current branch, that decision is already made.
+
+## Running
+
+- **Branch from the integration branch, not from whatever is checked out.**
+  The point of the isolated copy is a clean starting state; inheriting
+  unrelated in-progress edits forfeits it and makes the eventual diff
+  unreadable. Fetch first so the base is current, not a stale local ref.
+- **Leave the main working copy alone while the task runs.** Editing both
+  defeats the isolation and destroys the baseline. If the task turns out to
+  need a change in the main tree, stop and say so rather than reaching
+  across.
+- **Keep the worktree's scope to its own task.** Parallel worktrees on one
+  repository stay independent only if each one edits what it was opened for;
+  two of them touching the same files converge into a conflict nobody
+  scheduled.
+- **Name the artifacts' destination explicitly.** Screenshots, builds, and
+  exports produced inside a worktree vanish with it. Anything the requester
+  needs to see must be written somewhere durable, or attached to the PR, and
+  the location has to be stated rather than assumed.
+
+## Before declaring it done
+
+- **Compare against the untouched baseline, not against expectation.** The
+  reason to keep a clean copy is to run both and see the difference. For
+  behavior changes this means exercising the old path and the new one; for
+  visual changes it means the same view captured twice. "Should be
+  equivalent" is a claim, and the baseline is right there to check it.
+- **Confirm the diff contains only this task.** Generated files, formatter
+  churn, and dependency lock updates ride along easily and are hard to
+  distinguish from intent once merged.
+
+## Landing
+
+Push the branch and open a pull request describing motivation, the commands
+exercised, and anything reviewers must check by hand; leave merging to the
+repository owner unless told otherwise. Say plainly which parts are done,
+which are unverified, and which were deliberately left out, since a
+worktree's isolation makes it easy to report an untested result as
+finished. Once the branch has landed, remove the worktree; a stale copy of a
+merged branch is a trap for the next session that opens it.

--- a/skills/worktree-pr/SKILL.md
+++ b/skills/worktree-pr/SKILL.md
@@ -14,6 +14,10 @@ A worktree buys two things: the main working copy stays usable while the task
 runs, and the untouched copy remains available as a baseline to compare
 against. Both are worth real setup cost, and neither applies to every change.
 
+This covers the isolation mechanics. How large the change itself should be is
+[`scoped-change`](../scoped-change/SKILL.md), and it applies inside a
+worktree exactly as it does anywhere else.
+
 ## Deciding
 
 Open a worktree when at least one holds: the task is large enough that a
@@ -38,10 +42,10 @@ current branch, that decision is already made.
   defeats the isolation and destroys the baseline. If the task turns out to
   need a change in the main tree, stop and say so rather than reaching
   across.
-- **Keep the worktree's scope to its own task.** Parallel worktrees on one
-  repository stay independent only if each one edits what it was opened for;
-  two of them touching the same files converge into a conflict nobody
-  scheduled.
+- **Parallel worktrees stay independent only while they stay disjoint.** Two
+  copies of one repository editing the same files converge into a conflict
+  nobody scheduled, and the cost lands at merge time rather than now. Before
+  opening a second one, check what the first is touching.
 - **Name the artifacts' destination explicitly.** Screenshots, builds, and
   exports produced inside a worktree vanish with it. Anything the requester
   needs to see must be written somewhere durable, or attached to the PR, and
@@ -54,9 +58,10 @@ current branch, that decision is already made.
   behavior changes this means exercising the old path and the new one; for
   visual changes it means the same view captured twice. "Should be
   equivalent" is a claim, and the baseline is right there to check it.
-- **Confirm the diff contains only this task.** Generated files, formatter
-  churn, and dependency lock updates ride along easily and are hard to
-  distinguish from intent once merged.
+- **Account for what the tooling added.** Generated output, formatter churn,
+  and dependency lock updates accumulate in an isolated copy without anyone
+  choosing them, and they are indistinguishable from intent once merged.
+  Either explain why each belongs in this branch, or drop it.
 
 ## Landing
 


### PR DESCRIPTION
> **合并顺序**：本 PR 的 `worktree-pr` 链接到 `scoped-change`，请先合 #6 再合本 PR，否则那个相对链接会指向不存在的文件。

## Motivation

Both skills come from the same review of local agent transcripts that produced `scoped-change` (#6). Two recurring workflows had no home.

## worktree-pr

Running a task in an isolated copy showed up as a fixed routine across dozens of sessions, almost word for word: branch it, build it, compare it, open a PR. The negative case appeared too, being told explicitly to skip the worktree and work on the current branch, which is what makes the decision worth writing down rather than defaulting one way.

The skill covers isolation mechanics only. How large the change itself should be belongs to `scoped-change` and is linked rather than restated:

- when the isolation is worth its setup cost, and when it is pure overhead
- branch from the integration branch, not from whatever is checked out, or the eventual diff is unreadable
- the untouched copy exists to be compared against, not assumed equivalent
- parallel worktrees stay independent only while they stay disjoint
- generated output and lock churn accumulate in an isolated copy without anyone choosing them
- artifacts produced inside a worktree vanish with it, so their destination has to be named
- remove the worktree once the branch lands

## marketing-copy

Outbound copy is the one surface `ux-writing` explicitly does not cover, and the transcripts show why it needs its own rules. Recurring failure modes: access keys and unannounced URLs reaching a draft, platform limits differing between destinations carrying the same post, and claims outrunning what actually shipped.

Structure is disclosure first, then traceability, then attention, because a disclosure mistake is the only one that cannot be edited away after posting. Cross-links to `ux-writing` for product-internal text and `talk-like-scarletkc` for personal voice keep the boundaries explicit rather than duplicated.

## Sourcing and redaction

Rules are generalized from real sessions. No product name, domain, access key, platform name, or metric from those sessions appears in either file; verified by grep before commit.

## Commands exercised

```
python -m unittest discover -s tests            # Ran 6 tests — OK
python scripts/update_readme_skills.py          # regenerated catalog
python scripts/update_readme_skills.py --check  # exit 0
gh skill publish --dry-run                      # Dry run complete
```

Body line width is 77, matching `ux-writing`.

## Compatibility surface

None. Adds two skill directories and two generated README rows. Overlaps #6 in the README catalog block and in the cross-reference noted at the top.
