### PR TITLE
docs(ux-writing): preserve unaffected copy in revisions

### DIFF
--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -83,6 +83,12 @@ exception purely to suppress a traceback, keep the message intact.
   duplicates the canonical content and then ends with "see X for the full
   contract", it already is the full contract. Delete the restatement; keep
   the link and whatever is specific to this surface.
+- **Prefer the smallest sufficient edit.** When revising existing text,
+  preserve unaffected wording, structure, and rationale. Remove genuine
+  duplication, but do not rewrite neighboring prose or compress away useful
+  distinctions without a reason. *Counter-example: changing one mandatory
+  workflow into an optional one rewrote several surrounding sections, then
+  over-corrected by removing useful context; a few local edits were enough.*
 - **Insertion respects adjacency.** Before adding a section, check what the
   surrounding paragraphs attach to. *Counter-example: a new section landed
   between a flags table and its output-format footnote, orphaning the


### PR DESCRIPTION
## Summary

- add one documentation rule that prefers the smallest sufficient edit
- preserve unaffected wording, structure, and rationale during revisions
- distinguish removing genuine duplication from over-compressing useful context

## Why

The existing guidance discourages duplication, but it does not explicitly prevent a narrow copy change from expanding into a surrounding rewrite or an over-correction that removes useful distinctions.

## User and developer impact

Agents should make more focused documentation edits while preserving the document's existing voice and reasoning outside the requested change.

## Validation

- `python -m unittest discover -s tests -v` (6 passed)
- `python scripts/update_readme_skills.py --check`
- `gh skill publish --dry-run`
- `git diff --check`
