### PR TITLE
docs(scoped-change): clarify consequential boundary decisions

### DIFF
--- a/skills/scoped-change/SKILL.md
+++ b/skills/scoped-change/SKILL.md
@@ -69,6 +69,13 @@ boundary first, then be exhaustive inside it and inert outside it.
   every sibling declares, and only surfaced when a loader that groups by
   rarity silently dropped it.*
 
+## When the boundary is unclear
+
+- **Ask only for consequential boundary decisions.** If the requested boundary
+  cannot be determined without making a consequential choice the user has not
+  already made, ask before crossing it. Routine implementation decisions stay
+  with the agent and must not become confirmation gates.
+
 ## Order of work
 
 - **Lock behavior in tests once it is settled, not while it is moving.**


### PR DESCRIPTION
## Summary

- #10 correctly narrowed the `scoped-change` activation and removed overly broad confirmation gates.
- Add one narrow boundary rule for cases where the requested scope cannot be determined without a consequential choice the user has not already made.
- Keep routine implementation decisions with the agent so they do not become confirmation gates.

## Rationale

After the related rule was removed entirely, the skill no longer stated what to do when determining the request boundary itself requires a consequential user decision. This change restores only that missing behavior.

It does not restore the previous blanket confirmation requirement for structural changes.

## Scope

- Modified only `skills/scoped-change/SKILL.md`.
- Kept the existing activation narrowing and surrounding wording unchanged.

## Validation

- `python -m unittest discover -s tests -v` — 6 tests passed.
- `python scripts/update_readme_skills.py --check` — passed.
- Skill validator — passed.
- `git diff --check` — passed.
- Final comparison: 1 file changed, 7 additions, 0 deletions.
