### PR TITLE
docs(talk-like-scarletkc): clarify telegram_corpus.py location

### DIFF
--- a/skills/talk-like-scarletkc/references/anti-patterns.md
+++ b/skills/talk-like-scarletkc/references/anti-patterns.md
@@ -175,8 +175,8 @@ AI 收尾。真人讲完一件事就停了。
 它和 emoji、加粗一起出现时，基本可以判定那段话不是她写的，而是
 AI 输出。
 
-复现方式见 `scripts/telegram_corpus.py`，加 `--keep-pasted` 就是上面
-那个对照组。
+复现方式见 FogMoe/agents 仓库根目录的 `scripts/telegram_corpus.py`，
+它不随 skill 分发，加 `--keep-pasted` 就是上面那个对照组。
 
 ## 交付前自检清单
 


### PR DESCRIPTION
## 动机

`references/anti-patterns.md` 在讲硬规则实证依据时引用了
`scripts/telegram_corpus.py`，路径写法和同一份文件开头引用的
`scripts/lint_style.py` 一致，读起来像 skill 相对路径。但
`lint_style.py` 确实在 `skills/talk-like-scarletkc/scripts/` 下随 skill
分发，`telegram_corpus.py` 在仓库根目录的 `scripts/` 下，把 skill 复制到
`~/.claude/skills/` 的人拿不到这个文件，照着找会扑空。

## 改动

只改了一处措辞，点明它在 FogMoe/agents 仓库根目录且不随 skill 分发。

```diff
-复现方式见 `scripts/telegram_corpus.py`，加 `--keep-pasted` 就是上面
-那个对照组。
+复现方式见 FogMoe/agents 仓库根目录的 `scripts/telegram_corpus.py`，
+它不随 skill 分发，加 `--keep-pasted` 就是上面那个对照组。
```

顺带核对了 skill 包内其他路径引用（SKILL.md 资源表、evals.json 两处
`scripts/lint_style.py`），都指向包内实际存在的文件，无需改动。

## 验证

- `python -m pytest -q` → 24 passed
- `python skills/talk-like-scarletkc/scripts/lint_style.py skills/talk-like-scarletkc/references/anti-patterns.md`
  → 38 处提示，全部落在文件本身列举的反例清单行上（预期误报），
  改动的两行没有新增提示。

纯文档改动，不涉及 schema、公开 API 或兼容性表面。
