### PR TITLE
docs(ux-writing): keep intermediate state out of deliverables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ for the complete activation description and instructions.
 | [marketing-copy](skills/marketing-copy/SKILL.md) | Write outbound promo copy that stays truthful, discloses only what may be public, and earns attention without hype. |
 | [scoped-change](skills/scoped-change/SKILL.md) | Hold a change to the size the request defines: no unrequested surfaces, no speculative layers, no half-applied edits. |
 | [talk-like-scarletkc](skills/talk-like-scarletkc/SKILL.md) | Write and translate in scarletkc's natural voice without generic AI phrasing. |
-| [ux-writing](skills/ux-writing/SKILL.md) | Review user-facing copy and documentation for clarity, consistency, and facts that do not go stale. |
+| [ux-writing](skills/ux-writing/SKILL.md) | Review user-facing copy and documentation for clarity, consistency, facts that do not go stale, and no leftover intermediate state. |
 | [worktree-pr](skills/worktree-pr/SKILL.md) | Optionally run a task in its own worktree: branch from the integration branch, compare against the baseline, and prepare it for a PR. |
 <!-- skills:end -->
 

--- a/skills/scoped-change/SKILL.md
+++ b/skills/scoped-change/SKILL.md
@@ -16,6 +16,13 @@ and they fail differently: unrequested edits surface in review or in
 production, missing edits surface as the user finding them. Locate the
 boundary first, then be exhaustive inside it and inert outside it.
 
+When the boundary is corrected mid-task, the result reads as though the
+corrected scope were the only one there had ever been. A title, comment, or
+rationale that keeps the dropped option alive re-imports the overshoot the
+correction just removed, and the reader pays for it twice; what belongs in a
+deliverable is
+[`ux-writing`](https://github.com/FogMoe/agents/blob/main/skills/ux-writing/SKILL.md).
+
 ## Outside the boundary
 
 - **Edit only the surfaces the request names.** A request that names one

--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux-writing
-description: "Judgment rules for user-facing text and docs: CLI and diagnostic output, error and help text, README and docs structure, code comments, titles, and generated reports, decks, or exports. Use when writing or changing any user-visible string, when adding or restructuring docs or deciding which page owns a fact, when a page is about to record a version, a deployment state, or a value the code already owns, when a comment, title, or artifact could carry the reasoning or an abandoned option behind the change, or when reviewing a diff that touches copy or docs."
+description: "Judgment rules for user-facing text and docs: CLI and diagnostic output, error and help text, README and docs structure, code comments, titles, and generated reports, decks, or exports. Use when writing or changing any user-visible string, when adding or restructuring docs or deciding which page owns a fact, when a page is about to record a version, a deployment state, or a value the code already owns, when a comment, title, or artifact could carry the reasoning or an abandoned option behind the change, when a behavior change needs its copy sites swept, or when reviewing a diff that touches copy or docs."
 license: Apache-2.0
 metadata:
   author: scarletkc

--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux-writing
-description: "Judgment rules for user-facing text and documentation: CLI/tool output, status and diagnostic displays, error messages, help text, README and docs structure, keeping long-lived docs free of values that go stale, keeping comments, titles, and generated artifacts free of the reasoning behind them, and keeping copy in sync with behavior. Use when writing or changing any user-visible string, when adding or restructuring documentation, when deciding which document owns a fact or where a new page or section belongs, when a doc is about to record a version, a deployment state, or a value the code already owns, when writing a code comment or a pull request title, when producing a report, deck, or export, after a correction that could leave an abandoned option visible in any of them, or when reviewing a diff that touches copy or docs."
+description: "Judgment rules for user-facing text and docs: CLI and diagnostic output, error and help text, README and docs structure, code comments, titles, and generated reports, decks, or exports. Use when writing or changing any user-visible string, when adding or restructuring docs or deciding which page owns a fact, when a page is about to record a version, a deployment state, or a value the code already owns, when a comment, title, or artifact could carry the reasoning or an abandoned option behind the change, or when reviewing a diff that touches copy or docs."
 license: Apache-2.0
 metadata:
   author: scarletkc

--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ux-writing
-description: "Judgment rules for user-facing text and documentation: CLI/tool output, status and diagnostic displays, error messages, help text, README and docs structure, keeping long-lived docs free of values that go stale, and keeping copy in sync with behavior. Use when writing or changing any user-visible string, when adding or restructuring documentation, when deciding which document owns a fact or where a new page or section belongs, when a doc is about to record a version, a deployment state, or a value the code already owns, or when reviewing a diff that touches copy or docs."
+description: "Judgment rules for user-facing text and documentation: CLI/tool output, status and diagnostic displays, error messages, help text, README and docs structure, keeping long-lived docs free of values that go stale, keeping comments, titles, and generated artifacts free of the reasoning behind them, and keeping copy in sync with behavior. Use when writing or changing any user-visible string, when adding or restructuring documentation, when deciding which document owns a fact or where a new page or section belongs, when a doc is about to record a version, a deployment state, or a value the code already owns, when writing a code comment or a pull request title, when producing a report, deck, or export, after a correction that could leave an abandoned option visible in any of them, or when reviewing a diff that touches copy or docs."
 license: Apache-2.0
 metadata:
   author: scarletkc
   fogmoe-source: https://github.com/FogMoe/agents
-  fogmoe-summary: "Review user-facing copy and documentation for clarity, consistency, and facts that do not go stale."
+  fogmoe-summary: "Review user-facing copy and documentation for clarity, consistency, facts that do not go stale, and no leftover intermediate state."
 ---
 
 # UX Writing & Docs
@@ -167,6 +167,49 @@ applied to prose.
   "current environment" table listing service versions was updated by hand
   after every deploy, until the deploy where it wasn't, and nothing in CI
   could notice.*
+
+## The final state, not the path to it
+
+A deliverable is read by someone who was not in the room while it was made.
+Anything that only holds against the conversation behind it — an option
+that was considered and dropped, a scope that was corrected, an instruction
+the requester gave ten minutes ago — reads as noise at best, and at worst
+as a claim about the product. Session context expires faster than the
+artifact carrying it, so this is "facts that go stale" applied to the
+conversation rather than to time. The test for any line: does it hold for a
+reader who has never seen that conversation? "Without the bulk-download
+panel" does not, because nobody expected one. "Not `json.dumps` here, the
+payload has to keep key order for the signature check" does.
+
+- **State what the code does, not what it nearly did.** Titles, summaries,
+  and comments describe the shipped behavior; intermediate attempts,
+  abandoned options, and negative scope belong to the discussion that
+  produced them, which git history and the review thread already keep.
+  *Counter-example: a requested cut left the pull request titled "Add
+  export button (without the bulk-download panel)", so every reader had to
+  understand a panel that never existed before reading the one that did.*
+- **A comment carries the non-obvious reason only.** What earns the lines
+  is a constraint the next reader cannot recover from the code: an ordering
+  requirement, an upstream bug, a platform quirk. A "why not X" line
+  qualifies when X is what that reader would reach for anyway, not when X
+  is merely what this conversation happened to try and discard. Restating
+  what the code plainly says, or defending it against an alternative nobody
+  would propose, spends attention now and becomes a lie when the code
+  around it moves. *Counter-example: a helper kept eight lines on why it
+  held no cache, written the moment a reviewer asked for the cache to go;
+  two rewrites later the paragraph was the only trace of either.*
+- **A deliverable does not narrate its own production.** Generated reports,
+  decks, exports, and screens are product content: they carry findings,
+  values, and instructions, never the implementation notes, method
+  rationale, or next steps of whoever produced them. "This page
+  demonstrates", "we could also", and "implemented as" are the producer's
+  voice leaking into the product, and the exceptions are narrow — copy that
+  genuinely is help text or an empty state, and documents explicitly asked
+  to record their own methodology. Reasoning has its own homes: the reply
+  to the requester, the commit message, the pull request body, a planning
+  file. *Counter-example: a generated status deck opened on a slide titled
+  "Approach and next steps for this report", ahead of the numbers it had
+  been asked for.*
 
 ## Sync sweep for behavior changes
 

--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -73,6 +73,16 @@ exception purely to suppress a traceback, keep the message intact.
   after shipping, so the rules lived half there and half in the architecture
   doc; folding the stable rules into the contract and leaving the sequence in
   git history left one page to trust.*
+- **Rationale is a genre of its own.** A how-to answers what to run, a
+  reference answers what exists, and why-it-was-built-this-way belongs to a
+  design record, an ADR, or the pull request that decided it. Answering the
+  design question inside a usage page pushes the steps the reader came for
+  below the fold, and the argument is also the part that rots first: the
+  implementation moves on and only the guide still defends the old choice.
+  An explanation produced because someone asked once belongs in that
+  answer, not in a permanent page. *Counter-example: a setup guide spent
+  its second paragraph on why this queue was chosen over two others; the
+  queue was replaced a release later and the paragraph outlived it.*
 - **One canonical home per fact.** Details that change together (field
   lists, precedence chains, supported values) live in exactly one document;
   every other mention links to it. Legitimate copies: artifacts distributed


### PR DESCRIPTION
## Motivation

A widely shared complaint about agent behavior names two failures, and only
one of them had a rule here. The first — piling unrequested work onto a
request — is `scoped-change`. The second is what the *correction* leaves
behind: a pull request titled "feature (without the thing nobody asked
for)", a comment arguing at length against an alternative nobody would have
proposed, a generated document opening on the producer's method instead of
the reader's answer.

Underneath both sits a habit worth naming separately: explaining *why*
where the reader only asked *what*. The explanation is usually correct and
still misplaced, and it is the part that rots first when the code moves.

Nothing in this repository covered any of it. `ux-writing` had no rule
about comments or titles, `marketing-copy` only reaches outbound promo
copy, and a grep for the residue vocabulary across `skills/` returned
nothing.

## What changed

- **`ux-writing` gains "The final state, not the path to it"** — three
  rules resting on one reader test: does this line hold for someone who
  never saw the conversation? The test is what keeps a genuine non-obvious
  `why not X` comment while ruling out the conversational residue. X
  qualifies when the next reader would reach for it anyway, not when it is
  merely what this session tried and dropped.
- The section sits after **Facts that go stale** and borrows its reasoning:
  session context expires faster than the artifact carrying it, so this is
  the same defect measured against the conversation instead of against time.
- **The Documentation section gains "Rationale is a genre of its own"** — a
  how-to answers what to run, a reference answers what exists, and the
  design argument belongs to a design record, an ADR, or the pull request
  that decided it. An explanation produced because someone asked once
  belongs in that answer, not in a permanent page.
- **`scoped-change` cross-references the new section**, since a corrected
  boundary is where the residue gets created.
- **The activation description absorbs three new surfaces at close to its
  original length** — 611 characters against 570. It loads every session
  while the body loads only on a hit, so the overlap between its capability
  list and its trigger list was worth folding out; every chapter still has
  a phrase that reaches it.
- `README.md` regenerated from the metadata.

## Commands exercised

```
$ python scripts/update_readme_skills.py
$ python scripts/update_readme_skills.py --check
CHECK OK
$ python -m unittest discover -s tests
Ran 24 tests in 0.039s

OK
```

## For review

The exceptions are the judgment calls. A deliverable may still narrate its
own production when the copy genuinely is help text or an empty state, or
when the document was explicitly asked to record its own methodology; and
a comment may still argue against an alternative when the next reader would
have reached for it anyway. Everything else the producer knows goes to the
reply, the commit message, this body, or a planning file.
