### PR TITLE
docs(ux-writing): separate reader evidence from author self-defense

### DIFF
--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -208,6 +208,19 @@ payload has to keep key order for the signature check" does.
   around it moves. *Counter-example: a helper kept eight lines on why it
   held no cache, written the moment a reviewer asked for the cache to go;
   two rewrites later the paragraph was the only trace of either.*
+- **Evidence serves the reader's decision, not the author's doubt.** A
+  claim the reader has to act on — this one is faster, this default is
+  safe, use this over that — owes its basis, and "adjectives need evidence"
+  above says where the basis comes from. A statement of what the code does
+  owes nothing, because nobody is being asked to believe anything: a cited
+  standard, a benchmark number, or an appeal to consensus attached to it is
+  answering a challenge that was never made. The test is whether removing
+  the line changes what the reader can decide. Cited figures also age
+  faster than the sentence carrying them, and nobody comes back to
+  re-measure. *Counter-example: a config page defended its default with
+  "benchmarks show a 40% improvement", measured two majors earlier against
+  a code path that no longer existed; support was still quoting the
+  number.*
 - **A deliverable does not narrate its own production.** Generated reports,
   decks, exports, and screens are product content: they carry findings,
   values, and instructions, never the implementation notes, method


### PR DESCRIPTION
## Motivation

A distinct habit from the one #15 covered, and the more disguised of the
two: attaching evidence to a statement nobody challenged. `#15` ruled out
arguing against an alternative that was actually proposed and then dropped.
This is the case where no one proposed anything — a docstring citing the
RFC that permits what it does, a config default carrying a benchmark
number, a comment appealing to consensus. It reads as rigor, which is why
it survives review.

The rule cannot be "don't cite", because `ux-writing` already requires the
opposite in **Adjectives need evidence**: "recommended", "faster", and
"better" must come from your own benchmarks. Left alone, that rule reads as
licence for both. So the new one draws the line rather than adding a ban.

## What changed

One rule in **The final state, not the path to it**, placed after the
comment rule and before the generated-artifact rule:

> **Evidence serves the reader's decision, not the author's doubt.**

- A claim the reader has to act on owes its basis, and **Adjectives need
  evidence** already says where that basis comes from.
- A statement of what the code does owes nothing — nobody is being asked to
  believe anything, so the citation answers a challenge that was never made.
- The test: does removing the line change what the reader can decide?
- Secondary failure, cross-referencing **Facts that go stale**: cited
  figures outlive what they measured, and nothing in the page notices.

The activation description is unchanged — its existing "could carry the
reasoning behind the change" clause already reaches this, and the
description loads every session while the body loads only on a hit.

## Commands exercised

```
$ python scripts/update_readme_skills.py --check
CHECK OK
$ python -m unittest discover -s tests
Ran 24 tests in 0.106s

OK
```

## For review

The boundary against **Adjectives need evidence** is the judgment call.
Read together: a claim earns a citation, a description does not. If that
line feels too fine in practice, the two rules should probably be merged
into one paragraph rather than left to be reconciled by the reader.
