### PR TITLE
docs(marketing-copy): point the adjective rule at its canonical home

### DIFF
--- a/skills/marketing-copy/SKILL.md
+++ b/skills/marketing-copy/SKILL.md
@@ -50,10 +50,12 @@ quietly keeping it.
 ## Claims stay traceable
 
 Take substance from what actually shipped: the changelog, the commit range,
-the release notes. Every concrete claim should trace to one of those, and
-specifics beat adjectives at the same length. A number, a mechanism, or a
+the release notes. Every concrete claim traces to one of those, and an
+adjective that carries a claim owes what "adjectives need evidence" in
+`ux-writing` asks of it. What outbound adds is the exchange rate: specifics
+beat adjectives at the same length, because a number, a mechanism, or a
 before-and-after carries conviction that "greatly improved" cannot, and it
-also survives a reader who checks.
+survives a reader who checks.
 
 Never invent a metric, a benchmark, a user count, a review quote, or a
 comparison against a named competitor. When the honest version is thin, that


### PR DESCRIPTION
## Motivation

Two skills were maintaining the same judgment:

- `ux-writing` → **Adjectives need evidence**: "recommended", "faster",
  "better" come from your own benchmarks.
- `marketing-copy` → **Claims stay traceable**: every concrete claim traces
  to what shipped, and specifics beat adjectives.

`ux-writing`'s own **One canonical home per fact** and **Restating and
linking is a bug** rule that out, and its tie-breaker names the winner: the
broader responsibility keeps the shared rules, the narrower keeps only what
its own surface adds.

## What changed

`marketing-copy` now points at the shared bar instead of restating it, and
keeps what is genuinely outbound: where the substance comes from (changelog,
commit range, release notes), the exchange rate — specifics beat adjectives
at equal length — and the invented metrics, user counts, review quotes, and
competitor comparisons that only outbound copy is tempted by.

Net +2 lines. The point is not size, it is that the two copies can no longer
drift apart silently.

## Commands exercised

```
$ python scripts/update_readme_skills.py --check
CHECK OK
$ python -m unittest discover -s tests
Ran 24 tests in 0.044s

OK
```

## Not in this change

Renaming `ux-writing` to something that admits it now covers comments and
titles, and folding `marketing-copy` in as a sub-document, were both
considered and left out — the rename is worth doing together with an
eventual split so external links break once rather than twice, and the fold
would make every outbound post load 4.2k tokens of in-product rules while
demoting the disclosure section to a paragraph in a longer file.
