### PR TITLE
feat(skills): add ZIP packaging tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 # 语料分析的本地产物。配置含个人标识，候选清单含聊天原文，都不入库。
 .telegram-corpus.json
 /corpus/
+/dist/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ npx skills add scarletkc/agents --skill <skill> --agent codex -g -y
 
 Update global skills with `npx skills update -g -y`.
 
+## Package a skill
+
+Create a ZIP for a web app that accepts skill uploads:
+
+```sh
+python scripts/package_skill.py <skill>
+```
+
+The archive is written to `dist/<skill>.zip`. Its root contains `SKILL.md`
+and the skill's supporting files, ready to upload as one file. Root-level
+`evals/` and local build artifacts are excluded.
+
 ## Feedback and contributions
 
 Report problems or suggest improvements through

--- a/scripts/package_skill.py
+++ b/scripts/package_skill.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Package one repository skill as an upload-ready ZIP archive."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import os
+import re
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+SKILL_NAME = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+EXCLUDED_DIRS = {".git", "__pycache__", "node_modules"}
+ROOT_EXCLUDED_DIRS = {"evals"}
+EXCLUDED_FILES = {".DS_Store", "Thumbs.db"}
+EXCLUDED_GLOBS = {"*.pyc", "*.pyo"}
+ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+
+
+class PackageError(ValueError):
+    """Raised when a skill cannot be packaged safely."""
+
+
+def _should_exclude(relative_path: Path) -> bool:
+    if relative_path.parts and relative_path.parts[0] in ROOT_EXCLUDED_DIRS:
+        return True
+    if any(part in EXCLUDED_DIRS for part in relative_path.parts):
+        return True
+    if relative_path.name in EXCLUDED_FILES:
+        return True
+    return any(fnmatch.fnmatch(relative_path.name, pattern) for pattern in EXCLUDED_GLOBS)
+
+
+def _skill_files(skill_path: Path) -> list[tuple[Path, Path]]:
+    files: list[tuple[Path, Path]] = []
+    for path in skill_path.rglob("*"):
+        relative_path = path.relative_to(skill_path)
+        if _should_exclude(relative_path):
+            continue
+        if path.is_symlink():
+            raise PackageError(f"{path}: symbolic links are not supported")
+        if path.is_file():
+            files.append((relative_path, path))
+    return sorted(files, key=lambda item: item[0].as_posix())
+
+
+def _write_file(archive: zipfile.ZipFile, relative_path: Path, source: Path) -> None:
+    info = zipfile.ZipInfo(relative_path.as_posix(), ZIP_TIMESTAMP)
+    info.create_system = 3
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = 0o100644 << 16
+    with source.open("rb") as input_file, archive.open(info, "w") as output_file:
+        shutil.copyfileobj(input_file, output_file)
+
+
+def package_skill(repo_root: Path, skill_name: str, output_dir: Path) -> Path:
+    """Package ``skills/<skill_name>`` with its contents at the archive root."""
+    if SKILL_NAME.fullmatch(skill_name) is None:
+        raise PackageError(
+            "skill name must contain only lowercase letters, numbers, and single hyphens"
+        )
+
+    repo_root = repo_root.resolve()
+    skill_path = (repo_root / "skills" / skill_name).resolve()
+    skills_root = (repo_root / "skills").resolve()
+    if skill_path.parent != skills_root:
+        raise PackageError(f"{skill_name!r}: skill must be a direct child of {skills_root}")
+    if not skill_path.is_dir():
+        raise PackageError(f"{skill_path}: skill directory does not exist")
+    if not (skill_path / "SKILL.md").is_file():
+        raise PackageError(f"{skill_path}: SKILL.md is missing")
+
+    output_dir = output_dir.resolve()
+    if output_dir == skill_path or skill_path in output_dir.parents:
+        raise PackageError(f"{output_dir}: output directory must be outside the skill")
+
+    files = _skill_files(skill_path)
+    if Path("SKILL.md") not in {relative_path for relative_path, _ in files}:
+        raise PackageError(f"{skill_path}: SKILL.md cannot be packaged")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{skill_name}.zip"
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=output_dir, prefix=f".{skill_name}-", suffix=".zip", delete=False
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+        with zipfile.ZipFile(temporary_path, "w") as archive:
+            for relative_path, source in files:
+                _write_file(archive, relative_path, source)
+        os.replace(temporary_path, output_path)
+    except (OSError, zipfile.BadZipFile) as exc:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        raise PackageError(f"could not create {output_path}: {exc}") from exc
+    return output_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("skill", help="name of a directory under skills/")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="archive destination (default: dist/ in the repository)",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parent.parent
+    output_dir = args.output_dir or repo_root / "dist"
+    try:
+        output_path = package_skill(repo_root, args.skill, output_dir)
+    except (PackageError, OSError) as exc:
+        parser.error(str(exc))
+    print(f"Packaged {args.skill} to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_package_skill.py
+++ b/tests/test_package_skill.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from scripts.package_skill import PackageError, package_skill
+
+
+class PackageSkillTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.skill = self.root / "skills" / "example-skill"
+        self.skill.mkdir(parents=True)
+        (self.skill / "SKILL.md").write_text(
+            "---\nname: example-skill\n---\n", encoding="utf-8"
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_packages_skill_contents_at_archive_root(self) -> None:
+        (self.skill / "references").mkdir()
+        (self.skill / "references" / "guide.md").write_text(
+            "Guide", encoding="utf-8"
+        )
+
+        output = package_skill(self.root, "example-skill", self.root / "dist")
+
+        with zipfile.ZipFile(output) as archive:
+            self.assertEqual(archive.namelist(), ["SKILL.md", "references/guide.md"])
+            self.assertEqual(archive.read("references/guide.md"), b"Guide")
+            self.assertNotIn("example-skill/SKILL.md", archive.namelist())
+
+    def test_excludes_development_artifacts(self) -> None:
+        (self.skill / "evals").mkdir()
+        (self.skill / "evals" / "evals.json").write_text("{}", encoding="utf-8")
+        (self.skill / "scripts" / "__pycache__").mkdir(parents=True)
+        (self.skill / "scripts" / "__pycache__" / "helper.pyc").write_bytes(b"cache")
+        (self.skill / "Thumbs.db").write_bytes(b"cache")
+
+        output = package_skill(self.root, "example-skill", self.root / "dist")
+
+        with zipfile.ZipFile(output) as archive:
+            self.assertEqual(archive.namelist(), ["SKILL.md"])
+
+    def test_repeated_packages_are_identical(self) -> None:
+        output = package_skill(self.root, "example-skill", self.root / "dist")
+        first = output.read_bytes()
+
+        output = package_skill(self.root, "example-skill", self.root / "dist")
+
+        self.assertEqual(output.read_bytes(), first)
+
+    def test_rejects_invalid_skill_name(self) -> None:
+        with self.assertRaisesRegex(PackageError, "skill name must contain"):
+            package_skill(self.root, "../example-skill", self.root / "dist")
+
+    def test_rejects_missing_skill_directory(self) -> None:
+        with self.assertRaisesRegex(PackageError, "skill directory does not exist"):
+            package_skill(self.root, "missing", self.root / "dist")
+
+    def test_rejects_missing_skill_file(self) -> None:
+        (self.skill / "SKILL.md").unlink()
+
+        with self.assertRaisesRegex(PackageError, "SKILL.md is missing"):
+            package_skill(self.root, "example-skill", self.root / "dist")
+
+    def test_rejects_output_inside_skill(self) -> None:
+        with self.assertRaisesRegex(PackageError, "must be outside the skill"):
+            package_skill(self.root, "example-skill", self.skill / "dist")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Web apps that accept uploaded skills need a single archive instead of a local skill directory. This adds a repository-native command for producing that artifact without manually selecting files or fixing the archive layout.

## What changed

- add `scripts/package_skill.py <skill>` to write `dist/<skill>.zip`
- place `SKILL.md` and supporting resources at the archive root
- exclude root-level evals and common local build artifacts
- reject invalid names, missing entry points, symlinks, and output paths inside the skill
- produce deterministic ZIP files and replace prior output atomically
- document the command and ignore generated archives

## Validation

- `python -m unittest discover -s tests -v` (31 tests passed)
- `python scripts/update_readme_skills.py --check`
- `gh skill publish skills --dry-run`
- packaged and integrity-checked all 6 repository skills
- `git diff --check`