### PR TITLE
feat(skills): add product-writing alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,18 @@ for the complete activation description and instructions.
 |-------|---------|
 | [codex-cli](skills/codex-cli/SKILL.md) | Reach for the Codex CLI when a task is hard enough to earn it: second-model review, bounded hand-offs, sandbox permissions, and a model and effort matched to the difficulty. |
 | [marketing-copy](skills/marketing-copy/SKILL.md) | Write outbound promo copy that stays truthful, discloses only what may be public, and earns attention without hype. |
+| [product-writing](skills/product-writing/SKILL.md) | Write accurate product copy and useful technical docs with a compact alternative to ux-writing. |
 | [scoped-change](skills/scoped-change/SKILL.md) | Hold a change to the size the request defines: no unrequested surfaces, no speculative layers, no half-applied edits. |
 | [talk-like-scarletkc](skills/talk-like-scarletkc/SKILL.md) | Write and translate in scarletkc's natural voice without generic AI phrasing. |
 | [ux-writing](skills/ux-writing/SKILL.md) | Review user-facing copy and documentation for clarity, consistency, facts that do not go stale, and no leftover intermediate state. |
 | [worktree-pr](skills/worktree-pr/SKILL.md) | Optionally run a task in its own worktree: branch from the integration branch, compare against the baseline, and prepare it for a PR. |
 <!-- skills:end -->
+
+[`product-writing`](skills/product-writing/SKILL.md) is a compact alternative to
+[`ux-writing`](skills/ux-writing/SKILL.md) for product copy and technical docs.
+Use one of these guides for a task. `ux-writing` retains the original, more
+detailed rules; `product-writing` leaves more structural and editorial choices
+to the task.
 
 ## Install skills
 

--- a/skills/product-writing/SKILL.md
+++ b/skills/product-writing/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: product-writing
+description: "Write, edit, or review product interface copy, CLI messages, help text, and technical documentation. Use when explaining product behavior, errors, status, setup, compatibility, or technical results. A compact alternative to ux-writing that preserves accuracy and reader context while leaving structure and phrasing to the task. Ordinary conversation, personal voice writing, and code-only reviews are outside its scope."
+license: Apache-2.0
+metadata:
+  author: scarletkc
+  source: https://github.com/scarletkc/agents
+  summary: "Write accurate product copy and useful technical docs with a compact alternative to ux-writing."
+---
+
+# Product Writing
+
+Help the reader understand what is happening and what they can do next.
+This skill is self-contained and can be used in place of `ux-writing`.
+Use one of these alternatives for a task; there is no prerequisite review
+with the other skill.
+
+## Work from the task
+
+Use only the sections relevant to the requested copy. Preserve the user's
+meaning, terminology, audience, and requested format. Follow existing product
+conventions where they help readers recognize controls, commands, and states.
+A wording task does not itself authorize changes to product behavior or a
+reorganization of the documentation.
+
+Ground behavioral claims in supplied facts, the relevant implementation or
+specification, or an observed result. When a fact cannot be verified, identify
+that uncertainty where it matters and complete the parts that are supported.
+Do not invent behavior or a cause to make the text sound complete.
+
+## Interface copy, errors, and help
+
+- **Name the action or state accurately.** Distinguish saving a setting from
+  testing a connection, accepting a request from completing a job, and partial
+  success from full success. For example, a queued export should not announce
+  that a file is ready to download.
+- **Make recovery useful.** Identify what failed and the relevant input or
+  operation. Include a next step when it is known and actionable. An unknown
+  network failure does not establish that credentials are wrong. Put detail
+  in the message, an expanded view, or a specific help link as the interface
+  allows; an error need not fill a fixed template.
+- **Preserve meaningful distinctions.** Keep prerequisites, limits, and
+  consequences that affect the reader's decision. Use the product's names for
+  controls and commands. Do not shorten away which item an action affects or
+  imply that an irreversible action is temporary.
+
+## Status and diagnostic output
+
+- **Describe the state the label promises.** Effective settings account for
+  runtime overrides; stored settings should be identified as such. If only
+  the API key comes from the environment, label that field rather than the
+  entire endpoint as environment-provided.
+- **Keep failure visible.** Distinguish unknown or unavailable values from
+  empty, missing, or default values. If partial results are supported, identify
+  what could not be checked. Follow the project's failure behavior instead of
+  introducing a fallback merely to produce a message.
+- **Preserve output contracts.** Keep prose and decoration out of JSON, TSV,
+  and other machine formats. Use existing diagnostic channels for explanations.
+  Keep paths, IDs, and commands complete where users need to copy them, subject
+  to the product's redaction rules.
+- **Choose useful detail.** A health summary may emphasize problems; an
+  inspection view may need complete values. Preserve the context needed for
+  either use, and check adjacent labels for duplication or ambiguity.
+
+## Documentation and technical explanations
+
+- **Keep explanations that earn their place.** A short rationale can belong
+  beside a setup step. Reports need enough method, source context, assumptions,
+  and limitations for readers to assess the findings. Remove production chatter
+  and abandoned options that add no useful context; retain relevant tradeoffs
+  and requested design history.
+- **Avoid competing specifications.** Keep a maintained source for detailed
+  contracts and link other pages to it. Summaries and examples beside links
+  can make a page usable on its own. Check repeated details for agreement;
+  duplication alone is not a reason to delete useful context.
+- **Scope changeable facts.** Supported versions, pinned installation commands,
+  and compatibility limits may be essential. Check them against the maintained
+  source. Date runtime observations in reports; point to a live check when the
+  reader needs current state. A merged change alone does not establish deployment.
+- **Make the next reference useful.** Link to the section, command, API entry,
+  or symbol that answers the reader's question. Keep caveats next to the steps
+  they qualify. Preserve working anchors and requested structure; organize by
+  the reader's task without imposing a fixed number of sections or purposes.
+
+## Claims and evidence
+
+Match the support to the claim. Performance comparisons need applicable
+measurements or a cited result with its scope. Compatibility claims need the
+relevant implementation or maintained specification. An editorial recommendation
+can explain a concrete benefit, such as naming the failed field so the reader
+can locate it; recommending clearer wording does not require a benchmark.
+
+Keep observations, hypotheses, preferences, and recommendations distinct.
+Preserve user-provided opinions as opinions. Qualify unsupported claims or
+explain the gap rather than invent proof or erase useful uncertainty.
+
+## Review and verification
+
+In a review, identify the wording, its effect on the reader, and a concrete
+correction when the evidence supports one. If the copy already works, say so;
+optional preferences should not become required rewrites. For an editing task,
+make the requested edits and explain consequential choices only as needed.
+
+Check meaning, terminology, formatting, and affected links. When behavior
+changes, search for dependent help text, errors, documentation, and bundled
+skill descriptions that need the same update. Keep catalog and localization
+entries in sync where applicable; avoid turning a small edit into a general audit.
+
+Use the project's relevant checks. When output behavior changes, cover success
+and failure: parse machine formats and check channels; for human messages,
+assert the relevant information without relying on incidental wrapping or color.

--- a/skills/product-writing/evals/evals.json
+++ b/skills/product-writing/evals/evals.json
@@ -1,0 +1,117 @@
+{
+  "skill_name": "product-writing",
+  "evals": [
+    {
+      "id": 1,
+      "name": "diagnostic-partial-state",
+      "prompt": "Correct this diagnostic summary: API key: missing; endpoint: default. The environment actually provides a configured key. The configuration file failed to parse, so the endpoint is unknown. The command already supports partial results. Only the messages are in scope.",
+      "expected_output": "Report that the key is configured, the endpoint is unknown, and configuration parsing failed. Preserve the existing partial-result behavior.",
+      "assertions": [
+        "Does not report the configured key as missing or reveal its value",
+        "Reports the endpoint as unknown or unavailable rather than default",
+        "Identifies the configuration failure without introducing a new fallback"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "machine-output-contract",
+      "prompt": "Review a proposed message change to an export command. On success, stdout contains one JSON object and callers parse the entire stream. The proposal adds 'Export complete' before the JSON. On failure, it adds error prose to stdout. The existing failure contract requires empty stdout and diagnostics on stderr.",
+      "expected_output": "Identify both output-contract violations and keep human messages on the existing diagnostic or human-readable path.",
+      "assertions": [
+        "Preserves successful stdout as one parseable JSON object",
+        "Preserves empty stdout and stderr diagnostics on failure",
+        "Does not require callers to adapt to a new format merely to accommodate the prose"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "setup-keeps-version-and-rationale",
+      "prompt": "Polish this setup paragraph, keeping one paragraph and its link: The tool requires Python 3.12 or later. We recommend a virtual environment so project dependencies can be managed separately. Run python -m venv .venv to create it. The full dependency table is in [Dependencies](docs/dependencies.md). The minimum version has been verified against the project configuration.",
+      "expected_output": "Retain the minimum version, useful rationale, copyable command, and detailed documentation link in one paragraph.",
+      "assertions": [
+        "Preserves the requirement for Python 3.12 or later",
+        "Keeps the dependency-isolation rationale beside the setup instruction",
+        "Keeps the command and link intact instead of replacing the explanation with only a link",
+        "Does not split the page or change the requested paragraph structure"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "name": "report-preserves-method-and-runtime-uncertainty",
+      "prompt": "Turn these experiment notes into a short report colleagues can use for a release decision: Fixed input, same machine, 20 runs per version. New median 80 ms, old median 100 ms. Only small files were tested; large files are untested. The PR is merged, but production has not been checked.",
+      "expected_output": "Preserve the measurement conditions, results, coverage limit, and uncertainty about production deployment.",
+      "assertions": [
+        "Keeps the same-machine, fixed-input, 20-run method and both median values",
+        "Limits the performance finding to the tested workload and preserves the large-file gap",
+        "Does not remove the method as irrelevant production chatter",
+        "Does not describe the change as deployed or verified in production"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "name": "evidence-matches-claim",
+      "prompt": "Review two copy changes separately. First: replace 'Invalid configuration' with 'timeout must be a positive integer'. The validation code confirms that this error concerns exactly that constraint on that field. Second: add 'The new implementation is twice as fast' to the README, although no performance measurements exist.",
+      "expected_output": "Support the specific error message based on its concrete benefit and flag the unsupported performance comparison.",
+      "assertions": [
+        "Explains that naming the field and constraint helps the user correct the input",
+        "Does not require a benchmark or user study to judge the error wording",
+        "Does not accept or invent evidence for the twofold performance claim",
+        "Does not let the missing performance evidence block the independent message correction"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "name": "small-copy-edit-stays-local",
+      "prompt": "Only correct the spelling on this button. Everything else is fine. Its current label is Confrim.",
+      "expected_output": "Provide Confirm as the corrected label and keep the response proportionate to the task.",
+      "assertions": [
+        "Provides Confirm as the button label",
+        "Does not propose behavior changes, documentation restructuring, or a project-wide audit",
+        "Does not request evaluation data or add a test that merely asserts this spelling"
+      ],
+      "files": []
+    },
+    {
+      "id": 7,
+      "name": "queued-is-not-complete",
+      "prompt": "Write a toast for an export request. The API has accepted the request into a queue, but has not generated a file. The current toast says 'Export complete. Your file is ready.' Users can check progress on the existing Exports page. Keep the toast brief.",
+      "expected_output": "Accurately describe the queued export and point to the Exports page without promising completion or a download.",
+      "assertions": [
+        "Describes the export as queued or awaiting processing rather than finished",
+        "Uses the existing Exports destination for progress",
+        "Does not invent a completion time, automatic notification, or download link"
+      ],
+      "files": []
+    },
+    {
+      "id": 8,
+      "name": "valid-copy-needs-no-rewrite",
+      "prompt": "Review this error only for accuracy and usefulness: 'File exceeds the 20 MB limit. Choose a smaller file.' The upload accepts a single file, the verified limit is 20 MB, and this message appears only after that limit is exceeded. Do not propose alternate tones or change the limit.",
+      "expected_output": "Report that the message is accurate and actionable, with no required wording change.",
+      "assertions": [
+        "Recognizes that the failure and next action are already clear",
+        "Does not manufacture a required finding or rewrite based on preference",
+        "Does not change the upload limit or request a benchmark"
+      ],
+      "files": []
+    },
+    {
+      "id": 9,
+      "name": "unknown-error-cause",
+      "prompt": "Rewrite this connection error: 'Your API key is wrong. Generate a new one.' The only observed result was a request timeout. No authentication response was received, and no retry behavior has been confirmed. Give a concise replacement using only these facts.",
+      "expected_output": "Describe the connection attempt timing out without asserting an authentication failure or inventing recovery behavior.",
+      "assertions": [
+        "Reports the timeout rather than invalid credentials",
+        "Does not instruct the user to replace their key without evidence",
+        "Does not promise automatic retries or a successful recovery",
+        "Provides usable copy without blocking on the unknown root cause"
+      ],
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
产品文案和技术文档需要准确描述行为，也需要保留读者理解和操作所需的上下文。新增独立的 `product-writing` skill，为这些任务提供一套更精简的判断指南，保留原版 `ux-writing`，由使用者选择。

- 覆盖界面文案、CLI 消息、错误恢复、诊断状态、技术说明及证据判断，保留输出契约和必要信息。
- 结构、解释位置和文案修改幅度按任务决定；区分事实性主张与编辑建议，正确的文案无需强行改写。
- README 新增目录项和替代关系说明，两套指南可分别独立使用。
- 新增 9 个英文评估场景，覆盖部分诊断结果、机器输出、安装说明、实验报告、证据类型、小改动、排队状态、无需修改及未知错误原因。

验证：

- uv 管理的 Python 3.12：`python -m unittest discover -s tests -v`，31 项通过。
- `python scripts/update_readme_skills.py --check`、`quick_validate.py skills/product-writing`、`gh skill publish --dry-run`、`git diff --cached --check` 通过。
- 9 个英文 eval 定义的 JSON、必需字段、ID 和名称唯一性检查通过；模型评估尚未执行。
- 已对照基线确认 `ux-writing` 正文未变。
