### PR TITLE
docs(product-writing): restore concrete writing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ for the complete activation description and instructions.
 |-------|---------|
 | [codex-cli](skills/codex-cli/SKILL.md) | Reach for the Codex CLI when a task is hard enough to earn it: second-model review, bounded hand-offs, sandbox permissions, and a model and effort matched to the difficulty. |
 | [marketing-copy](skills/marketing-copy/SKILL.md) | Write outbound promo copy that stays truthful, discloses only what may be public, and earns attention without hype. |
-| [product-writing](skills/product-writing/SKILL.md) | Write accurate product copy and useful technical docs with a compact alternative to ux-writing. |
+| [product-writing](skills/product-writing/SKILL.md) | Write accurate product copy and useful technical docs. |
 | [scoped-change](skills/scoped-change/SKILL.md) | Hold a change to the size the request defines: no unrequested surfaces, no speculative layers, no half-applied edits. |
 | [talk-like-scarletkc](skills/talk-like-scarletkc/SKILL.md) | Write and translate in scarletkc's natural voice without generic AI phrasing. |
 | [ux-writing](skills/ux-writing/SKILL.md) | Review user-facing copy and documentation for clarity, consistency, facts that do not go stale, and no leftover intermediate state. |

--- a/skills/product-writing/SKILL.md
+++ b/skills/product-writing/SKILL.md
@@ -1,19 +1,16 @@
 ---
 name: product-writing
-description: "Write, edit, or review product interface copy, CLI messages, help text, and technical documentation. Use when explaining product behavior, errors, status, setup, compatibility, or technical results. A compact alternative to ux-writing that preserves accuracy and reader context while leaving structure and phrasing to the task. Ordinary conversation, personal voice writing, and code-only reviews are outside its scope."
+description: "Write, edit, or review UI copy, CLI messages, help text, code comments, and technical documentation covering product behavior, errors, status, setup, compatibility, or technical results."
 license: Apache-2.0
 metadata:
   author: scarletkc
   source: https://github.com/scarletkc/agents
-  summary: "Write accurate product copy and useful technical docs with a compact alternative to ux-writing."
+  summary: "Write accurate product copy and useful technical docs."
 ---
 
 # Product Writing
 
 Help the reader understand what is happening and what they can do next.
-This skill is self-contained and can be used in place of `ux-writing`.
-Use one of these alternatives for a task; there is no prerequisite review
-with the other skill.
 
 ## Work from the task
 
@@ -58,29 +55,81 @@ Do not invent behavior or a cause to make the text sound complete.
   and other machine formats. Use existing diagnostic channels for explanations.
   Keep paths, IDs, and commands complete where users need to copy them, subject
   to the product's redaction rules.
-- **Choose useful detail.** A health summary may emphasize problems; an
-  inspection view may need complete values. Preserve the context needed for
-  either use, and check adjacent labels for duplication or ambiguity.
+- **Give diagnostic views distinct jobs.** When a dedicated inspection command
+  already provides all values and origins, a health summary can focus on
+  deviations, failures, and their sources, with a pointer to full details.
+  Without that separate view, preserve the values needed to investigate the
+  problem. Fifteen normal `field: origin` rows can bury the two overrides that
+  matter, but removing the only available configuration view loses information.
+  Re-read adjacent labels to catch duplication such as `default (default)`.
 
 ## Documentation and technical explanations
 
-- **Keep explanations that earn their place.** A short rationale can belong
-  beside a setup step. Reports need enough method, source context, assumptions,
-  and limitations for readers to assess the findings. Remove production chatter
-  and abandoned options that add no useful context; retain relevant tradeoffs
-  and requested design history.
-- **Avoid competing specifications.** Keep a maintained source for detailed
-  contracts and link other pages to it. Summaries and examples beside links
-  can make a page usable on its own. Check repeated details for agreement;
-  duplication alone is not a reason to delete useful context.
-- **Scope changeable facts.** Supported versions, pinned installation commands,
-  and compatibility limits may be essential. Check them against the maintained
-  source. Date runtime observations in reports; point to a live check when the
-  reader needs current state. A merged change alone does not establish deployment.
+- **Give each page one responsibility.** A how-to completes an operation, a
+  reference defines a contract, a design record explains choices, and a report
+  presents findings and their basis. Put a section on the page that owns its
+  reader question. When a page mixes independent tasks, separate them and leave
+  a useful pointer at the boundary. An overview's responsibility is orientation:
+  summarize the available paths and link to their details instead of becoming
+  a second reference manual.
+- **Keep README sections focused.** The introduction identifies the product,
+  its audience, and its purpose. Positioning explains why someone would choose
+  it. Quick-start instructions give the shortest complete path to a useful
+  result, including prerequisites, commands, and essential caveats. Full option
+  catalogs, architecture explanations, and decision histories belong in their
+  respective documents, linked from the relevant section. Do not turn a quick
+  start into an architecture tour or a positioning section into a feature dump.
+  Keep a compatibility warning beside the step it affects; moving background
+  detail must not hide a condition needed to follow the instructions safely.
+- **Keep reasons near the decisions they support.** A setup step may need a
+  short explanation of why a prerequisite matters. A long history of rejected
+  designs usually belongs in a design record linked from the guide, unless
+  that history is the page's purpose. Reports need enough method, source context,
+  assumptions, and limitations for readers to assess the findings.
+- **Separate summaries from competing specifications.** Keep one maintained
+  source for a detailed contract. A summary explains what the reader needs now;
+  a second complete field table, default list, or precedence rule creates
+  another specification to maintain. For example, a README can show a minimal
+  configuration and link to the full schema instead of copying all seven fields
+  into another table. Detailed repetition may be necessary for independently
+  distributed artifacts; check how those copies stay synchronized.
+- **Plan how changeable facts stay correct.** Supported versions, pinned install
+  commands, and compatibility limits may be necessary. Verify them against the
+  maintained source, then check what will keep them aligned on the next change:
+  generation, an existing release check, or an explicit maintenance responsibility.
+  Avoid adding a second hand-maintained copy of a build ID, migration count, or
+  current deployment version just to make a page self-contained. Prefer a
+  pointer or generated value when the reader needs the current answer. Preserve
+  version constraints that are part of the instructions; do not remove them
+  simply because versions change.
+- **Distinguish records from live state.** A dated report can record the version
+  and status actually observed, with the evidence and limits of that observation.
+  A standing operational guide should direct readers to the command or dashboard
+  that answers what is running now. A merged change alone does not establish
+  deployment, and a successful deployment alone does not establish every health
+  or verification claim.
 - **Make the next reference useful.** Link to the section, command, API entry,
-  or symbol that answers the reader's question. Keep caveats next to the steps
-  they qualify. Preserve working anchors and requested structure; organize by
-  the reader's task without imposing a fixed number of sections or purposes.
+  or symbol that answers the reader's question. For implementation details,
+  `PROTOCOL_VERSION` is a useful pointer; a repository root leaves the reader
+  to search again. For normal setup, prefer user-facing instructions. Keep caveats
+  next to the steps they qualify and preserve working anchors.
+
+## Comments and standalone artifacts
+
+Read titles, comments, and deliverables as someone who has not seen the working
+conversation. Remove abandoned options and temporary scope qualifications that
+make sense only in that conversation. An export button title does not need
+"without the bulk-download panel" if readers were never offered such a panel.
+Keep exclusions when they explain a real contract, compatibility limit, or
+tradeoff the reader needs; preserve history in documents requested to record it.
+
+Comments are most useful for reasons the code does not make apparent: ordering
+constraints, upstream defects, compatibility workarounds, and invariants a later
+edit could break. Explain an alternative when it is one a maintainer would
+reasonably reach for. For example, a comment explaining why a lock must be
+released before invoking a callback can prevent a deadlock; "release the lock"
+merely repeats the operation. Do not replace that reason with a shorter restatement
+of the code. Keep public API documentation and useful algorithm overviews as well.
 
 ## Claims and evidence
 

--- a/skills/product-writing/evals/evals.json
+++ b/skills/product-writing/evals/evals.json
@@ -112,6 +112,97 @@
         "Provides usable copy without blocking on the unknown root cause"
       ],
       "files": []
+    },
+    {
+      "id": 10,
+      "name": "summary-versus-competing-contract",
+      "prompt": "Review two README proposals. The maintained configuration reference is generated from schema.py and contains seven fields with defaults. Proposal A adds a minimal working example and links to that reference. Proposal B manually copies the entire seven-field table, including defaults, and appends the same link. No process keeps the manual table synchronized. Which parts should we keep or change?",
+      "expected_output": "Keep the useful example and link; identify the full manual table as a competing contract and suggest linking to or generating it from the maintained source.",
+      "assertions": [
+        "Does not remove the minimal example just because a detailed reference exists",
+        "Explains why appending a link does not keep the duplicated table synchronized",
+        "Offers a maintained-source solution rather than merely checking today's values",
+        "Does not propose restructuring schema.py or unrelated documentation"
+      ],
+      "files": []
+    },
+    {
+      "id": 11,
+      "name": "maintainable-facts-and-dated-observations",
+      "prompt": "Review a standing operations guide that manually repeats the deployed build ID and migration count. The dashboard provides current deployment state and the migrations directory is authoritative for migrations; neither updates the guide. The same guide requires Python 3.12 or later, a verified compatibility constraint maintained by the existing release checklist. A separate dated incident report records the build observed during that incident. Explain what to preserve or change.",
+      "expected_output": "Replace or generate the unmaintained current-state copies, retain the supported Python requirement and its maintenance path, and preserve the incident report's dated observation.",
+      "assertions": [
+        "Addresses how the build ID and migration count will stay correct after future changes",
+        "Points current-state readers to the authoritative source or suggests generation from it",
+        "Does not delete the necessary Python version constraint",
+        "Distinguishes the historical incident observation from a claim about current deployment"
+      ],
+      "files": []
+    },
+    {
+      "id": 12,
+      "name": "standalone-copy-and-relevant-history",
+      "prompt": "Review these additions: a user-facing heading 'Export CSV without the bulk-download panel', where the panel was only an abandoned internal idea; a note that CSV export omits attachments, which is an actual limitation users need to know; and a paragraph explaining the rejected panel in an ADR explicitly intended to record that decision. Give a correction for the heading and assess the other two items.",
+      "expected_output": "Remove the abandoned panel from the heading while preserving the real attachment limitation and the ADR's relevant history.",
+      "assertions": [
+        "Provides a heading that makes sense without the internal conversation",
+        "Keeps the attachment exclusion because it describes the actual export contract",
+        "Keeps the requested decision history in the ADR",
+        "Does not apply a blanket prohibition on negative statements or rejected alternatives"
+      ],
+      "files": []
+    },
+    {
+      "id": 13,
+      "name": "comments-preserve-non-obvious-reasons",
+      "prompt": "Review a comment-only change before lock.release() and notify_listener(): the existing comment says 'Release before notifying: listeners can re-enter this object and acquire the same non-reentrant lock.' The replacement says 'Release the lock.' The re-entry behavior is verified. A separate public function docstring describes the accepted input and return value. Should either explanation be removed for brevity?",
+      "expected_output": "Preserve the ordering and deadlock rationale and retain the useful public API contract without changing executable code.",
+      "assertions": [
+        "Explains that the shorter comment loses the non-obvious reason for releasing the lock before notification",
+        "Preserves the listener re-entry and non-reentrant lock information",
+        "Does not remove public API documentation under a reasons-only rule",
+        "Does not redesign locking or callback behavior during the comment review"
+      ],
+      "files": []
+    },
+    {
+      "id": 14,
+      "name": "diagnostic-detail-depends-on-available-views",
+      "prompt": "Review the output structure for two tools. Tool A has a doctor summary with fifteen normal field-origin rows burying two problematic overrides; its existing inspect command shows every effective value and origin. Tool B has one diagnostic command, no other inspection view, and users need the displayed endpoint and timeout to investigate failures. Suggest output improvements using only these existing surfaces.",
+      "expected_output": "Focus Tool A's summary on problems and sources with a pointer to inspect; preserve Tool B's necessary diagnostic values because there is no separate view.",
+      "assertions": [
+        "Suggests surfacing the two problematic overrides and their origins in Tool A",
+        "Uses Tool A's existing inspect command for complete detail",
+        "Preserves Tool B's endpoint and timeout information",
+        "Does not prescribe delta-only output universally or invent a new inspection command"
+      ],
+      "files": []
+    },
+    {
+      "id": 15,
+      "name": "field-level-origin-claims",
+      "prompt": "Correct this configuration display: 'Endpoint settings (from environment): URL=https://api.example.com; API key=configured'. The URL comes from the config file. Only the key comes from an environment variable. Keep both facts visible and do not expose the key itself.",
+      "expected_output": "Attribute the URL to the config file and the configured key to the environment, without labeling the entire endpoint as environment-provided.",
+      "assertions": [
+        "Keeps the complete example URL and identifies its config-file source",
+        "Attributes only the key to the environment",
+        "Reports key presence without revealing or inventing its value"
+      ],
+      "files": []
+    },
+    {
+      "id": 16,
+      "name": "page-responsibility-and-readme-sections",
+      "prompt": "Review this proposed README outline: an introduction naming the product and audience; a Why Use It section containing the full configuration field catalog; a Quick Start that opens with four paragraphs about rejected storage designs, then gives the install and first-run commands; and a required database migration warning next to the first-run command. Existing Configuration Reference and Architecture Decision pages own the catalog and storage history. Recommend a concrete organization.",
+      "expected_output": "Keep the introduction and essential first-run path in the README, place detailed contracts and decision history on their owning pages, and retain the migration warning next to the affected command.",
+      "assertions": [
+        "Applies a concrete responsibility to positioning, quick start, reference, and design history rather than merely saying organization depends on preference",
+        "Moves or links the full field catalog to Configuration Reference and the storage history to the Architecture Decision page",
+        "Keeps prerequisites and commands needed to reach the first useful result in Quick Start",
+        "Preserves the migration warning at the point where the reader needs it",
+        "Does not propose a second competing reference or an unnecessary new documentation hierarchy"
+      ],
+      "files": []
     }
   ]
 }


### PR DESCRIPTION
`product-writing` 的精简版省略了部分有用的工程经验，description 和正文还包含面向安装者的替代关系说明。本次修订补回可执行的文档规则、适用条件和关键反例，让调用描述只承担技能发现的作用。

- 恢复页面单一职责、README 章节分工、摘要与完整规范的区别，以及易变事实的持续维护要求。
- 补充诊断视图的职责条件、脱离工作会话的可读性、注释中的非显而易见原因，并保留必要解释和真实限制。
- 精简 description 和 metadata summary，替代关系只在 README 说明，原版 `ux-writing` 不变。
- 英文评估场景从 9 项增至 16 项，覆盖新增规则的适用情形与边界。

验证：

- `quick_validate.py skills/product-writing`、`python scripts/update_readme_skills.py --check`、`git diff --cached --check` 通过。
- 16 个英文 eval 定义的 JSON、必需字段、ID 和名称唯一性检查通过；模型评估尚未运行。
- 仓库测试与技能发布预检由 PR CI 执行。
