### PR TITLE
feat(grok-cli): add skill and background ACP task client

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -31,3 +31,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh skill publish --dry-run
+
+  grok-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Test Grok ACP client on Windows
+        run: python -m unittest discover -s tests -p test_grok_acp.py -v

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ for the complete activation description and instructions.
 | Skill | Summary |
 |-------|---------|
 | [codex-cli](skills/codex-cli/SKILL.md) | Reach for the Codex CLI when a task is hard enough to earn it: second-model review, bounded hand-offs, sandbox permissions, and a model and effort matched to the difficulty. |
+| [grok-cli](skills/grok-cli/SKILL.md) | Delegate work to Grok Build, keep its session for follow-ups, and inspect results while the supervising agent continues working. |
 | [marketing-copy](skills/marketing-copy/SKILL.md) | Write outbound promo copy that stays truthful, discloses only what may be public, and earns attention without hype. |
 | [product-writing](skills/product-writing/SKILL.md) | Write accurate product copy and useful technical docs. |
 | [scoped-change](skills/scoped-change/SKILL.md) | Hold a change to the size the request defines: no unrequested surfaces, no speculative layers, no half-applied edits. |

--- a/skills/grok-cli/SKILL.md
+++ b/skills/grok-cli/SKILL.md
@@ -106,8 +106,10 @@ task ID means the worker started, not that Grok authenticated or finished.
 `completed` means Grok ended its turn, not that its claims were verified.
 Inspect the actual diff or cited evidence and run the relevant checks.
 
-On a tool, authentication, or process failure, surface the failure and
-inspect any partial result before retrying. Do not silently perform the
-task yourself and present it as Grok's work. Report what Grok contributed
-and what the supervising agent verified. Committing, publishing, and other
-external actions keep the authorization boundaries of the original task.
+If Grok is unavailable or an installation, configuration, authentication,
+tool, or process failure blocks the task, explicitly tell the user what
+failed and which work remains incomplete. Inspect any partial result before
+retrying. Do not silently substitute your own work, another agent, or another
+provider for the requested Grok task. Report what Grok contributed and what
+the supervising agent verified. Committing, publishing, and other external
+actions keep the authorization boundaries of the original task.

--- a/skills/grok-cli/SKILL.md
+++ b/skills/grok-cli/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: grok-cli
+description: "Delegate bounded tasks to Grok Build from a supervising agent such as Codex. Use when the user asks Grok to investigate, review, implement, or provide another perspective, or when a distinct coding agent would materially help. Includes a background ACP client for progress, follow-up prompts, permissions, and cancellation."
+license: Apache-2.0
+metadata:
+  author: scarletkc
+  source: https://github.com/scarletkc/agents
+  summary: "Delegate work to Grok Build, keep its session for follow-ups, and inspect results while the supervising agent continues working."
+---
+
+# Grok CLI
+
+Use Grok Build as a separate coding agent on the same machine. The bundled
+client launches `grok agent --no-leader stdio`, keeps its ACP session open,
+and returns a task ID immediately. This is an external task: it does not
+appear in Codex's native `spawn_agent` tree or inherit its conversation.
+
+Grok Build must already be installed and configured. Use the project's
+Python 3.12+ interpreter to run [scripts/grok.py](scripts/grok.py); the
+client uses only the standard library. If the project has no interpreter,
+`uv run --python 3.12 <script> ...` also works. Resolve the script relative
+to this installed skill, not the repository being investigated.
+
+## Delegate a task
+
+Give Grok the goal, absolute working directory, relevant files and evidence,
+scope boundaries, and the check that proves completion. It cannot see the
+conversation that led to the assignment. Keep independent work with the
+supervising agent while Grok runs.
+
+Use a UTF-8 prompt file for substantial instructions. In these examples,
+`<script>` is the absolute path to this skill's `scripts/grok.py`:
+
+```sh
+python <script> start --cwd <absolute-project-path> --prompt-file <task-file>
+python <script> wait <task_id> --timeout 30
+python <script> status <task_id>
+python <script> reply <task_id> --prompt-file <follow-up-file>
+python <script> cancel <task_id>
+python <script> close <task_id>
+```
+
+Retain the returned `task_id`. Use `wait` when there is no independent work
+left; its timeout returns the current state without cancelling the task.
+Use `reply` after the current turn finishes to continue the same Grok
+session. A running turn must finish or acknowledge cancellation before a
+follow-up is accepted. Close the task once no more follow-ups are needed.
+
+The helper's `--help` is the command reference. For output fields, storage,
+timeouts, and troubleshooting, read [references/client.md](references/client.md).
+
+## Configuration and permissions
+
+Inherit Grok's model, authentication, and permission configuration unless
+the task requires a specific override. Subscription login, API keys,
+and configured providers are Grok's concern; do not change the user's
+configuration or choose another authentication route to get past a failure.
+The helper uses Grok's advertised noninteractive default authentication
+method when available. Interactive authentication is completed separately
+through Grok itself.
+
+`start --model`, `--effort`, `--permission-mode`, and `--sandbox` are
+per-task overrides. Omit them when no override is needed. Do not use a
+permission bypass merely to avoid handling an approval request.
+
+Choose `--effort` for the delegated task. Honor the user's explicit choice;
+otherwise weigh complexity, the cost of an incorrect result, and how easily
+the result can be checked. Make routine choices without asking the user:
+
+- Simple chat, rewriting, or mechanical work can use a lower effort level.
+- Ordinary implementation and analysis generally suit a middle level.
+- Difficult debugging and consequential code review may justify a higher level.
+
+These are starting points, not fixed task-to-level rules. Use only levels
+known to be supported by the selected model. When support or the appropriate
+level is uncertain, omit `--effort` and inherit Grok's configured value.
+
+Match permissions to the authorized work. Preserve read-only restrictions
+for read-only assignments; allow the necessary file edits and checks for
+an authorized implementation within its scope. Task complexity and reasoning
+effort do not expand that authorization.
+
+When `status` is `needs_approval`, inspect `pending_permissions` and answer
+the relevant request with:
+
+```sh
+python <script> permission <task_id> --request-id <request_id> --option-id <optionId>
+```
+
+Select an option Grok actually offered. Approve actions already covered by
+the user's assignment; prefer a single-use approval. Decisions beyond that
+scope stay with the user. Configured Grok allow rules can execute tools
+without producing an ACP approval request. A read-only task prompt or
+refusing an ACP request is not an OS sandbox; Codex's sandbox does not
+configure Grok's. Do not promise enforced isolation without verifying
+Grok's sandbox on the target platform.
+
+## Supervise the result
+
+Avoid simultaneous edits to the same files. Use a separate worktree when
+both agents need to edit overlapping code, and pass its absolute path as
+`--cwd`; the helper does not create worktrees.
+
+Read `status`, `closed`, `stop_reason`, and `error` together. A returned
+task ID means the worker started, not that Grok authenticated or finished.
+`completed` means Grok ended its turn, not that its claims were verified.
+Inspect the actual diff or cited evidence and run the relevant checks.
+
+On a tool, authentication, or process failure, surface the failure and
+inspect any partial result before retrying. Do not silently perform the
+task yourself and present it as Grok's work. Report what Grok contributed
+and what the supervising agent verified. Committing, publishing, and other
+external actions keep the authorization boundaries of the original task.

--- a/skills/grok-cli/references/client.md
+++ b/skills/grok-cli/references/client.md
@@ -1,0 +1,89 @@
+# ACP client operations
+
+Run `scripts/grok.py --help` or `<command> --help` for flags and defaults.
+The client starts a private Grok process for each task. The process keeps
+its session until `close`, a connection failure, or the idle timeout.
+
+## Inputs and results
+
+`start` and `reply` accept `--prompt`, `--prompt-file`, or UTF-8 stdin.
+Prompt files can include a UTF-8 BOM. Prefer files to shell-quoted multiline
+text. The client passes an argument array to Grok and does not invoke a
+shell to interpret the prompt.
+
+Commands emit one JSON object on stdout. Unicode is escaped for Windows
+pipe compatibility. Runtime failures return a nonzero exit code and an
+`error`; argparse usage errors go to stderr. `status` and `wait` also exit
+nonzero for failed, timed-out, or unresponsive tasks. A successful exit
+with a running state means observation succeeded, not that Grok finished.
+
+| Field | Meaning |
+| --- | --- |
+| `task_id` | Helper ID used in every follow-up command |
+| `session_id` | Grok ACP session ID, available after initialization |
+| `status` | Starting, running, needs approval, cancelling, completed, cancelled, failed, timed out, or unresponsive |
+| `closed` | Whether the worker released its Grok process; closed tasks cannot accept replies |
+| `closing` | A close request is being processed; wait until `closed` is true |
+| `turn` | Turn number; each accepted reply starts another turn |
+| `text` | Accumulated assistant text from the current/latest turn |
+| `tools` | Up to ten recent tool names, statuses, and locations; full inputs and results are in the event log |
+| `pending_permissions` | Outstanding request IDs, tool context, and offered option IDs |
+| `stop_reason` | Grok's completion reason; `forced_stop` means cancellation required terminating its process tree |
+| `error` | Failure or incomplete-turn information, when present |
+| `log_dir` | Absolute path to this task's diagnostic files |
+
+`model` and `config_options` show the model and options returned by Grok.
+Missing fields mean that initialization has not reached that point, or the
+agent did not advertise the value. The helper does not inspect credential
+files or rewrite Grok configuration.
+
+## Waiting, cancellation, and follow-ups
+
+`wait` returns when a turn ends, the task closes, approval is needed, or
+its own timeout expires. It does not kill a running task.
+
+`cancel` sends ACP `session/cancel` and answers outstanding permissions
+with the cancelled outcome. Keep waiting until cancellation is acknowledged.
+If Grok acknowledges, `reply` can reuse the session. If Grok does not
+acknowledge within the cancellation grace period, the helper terminates
+that Grok process tree and closes the task. Cancellation does not undo
+file changes or external actions already performed.
+
+`close` cancels active work and releases the process. Finished results and
+logs remain readable. A turn timeout requests cancellation; an idle timeout
+closes an already-finished session. Configure these on `start` if the task
+needs longer. Sessions closed by the helper are not automatically reloaded.
+
+Control commands return a `command_id` once queued. Usually the worker
+acknowledges immediately and returns its new state. A
+`command_status: "queued"` result means acknowledgment has not arrived:
+inspect `status` before retrying, especially for `reply`, to avoid sending
+the same work twice.
+
+## Storage and diagnostics
+
+Task state is stored under `%LOCALAPPDATA%/grok-acp` on Windows, or
+`$XDG_STATE_HOME/grok-acp` (default `~/.local/state/grok-acp`) elsewhere.
+Use `--state-dir <absolute-path>` **before the command** to choose another
+location, and use the same location for all commands concerning that task.
+Keep it outside a shared or tracked repository: prompts, responses, tool
+events, and logs may contain project data.
+
+Each task has `events.jsonl` for prompts, streamed ACP updates, and turn
+results; `grok.log` for Grok stderr; and `worker.log` for helper diagnostics.
+Earlier turns remain in the event log after `reply` resets the current
+snapshot. Logs are not automatically deleted. Close tasks before removing
+their state directory.
+
+If a worker stops updating its heartbeat, `status` reports `unresponsive`
+instead of claiming that the saved running state is still live. Inspect its
+logs and process before launching replacement work. If authentication
+requires a browser, complete `grok login` outside the helper and start a
+new task. Model and provider failures belong to Grok's configuration;
+the helper does not switch providers or authentication methods on retry.
+
+The client advertises no filesystem or terminal callbacks: Grok executes
+its own tools. It handles permission requests and rejects unsupported
+client methods rather than leaving them waiting indefinitely. Protocol
+references: [Grok ACP](https://docs.x.ai/build/cli/headless-scripting) and
+[ACP prompt turns](https://agentclientprotocol.com/protocol/v1/prompt-turn).

--- a/skills/grok-cli/scripts/acp_client.py
+++ b/skills/grok-cli/scripts/acp_client.py
@@ -1,0 +1,111 @@
+"""Line-delimited ACP transport for the bundled Grok task runner."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import signal
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+
+
+class ACPError(RuntimeError):
+    pass
+
+
+class ACPClient:
+    def __init__(self, command: list[str], cwd: str, log_path: Path):
+        self.messages: queue.Queue[dict[str, Any] | Exception] = queue.Queue()
+        self.next_id = 0
+        self.log = log_path.open("ab")
+        self.job = None
+        options: dict[str, Any] = {}
+        if os.name == "nt":
+            options["creationflags"] = subprocess.CREATE_NO_WINDOW
+        else:
+            options["start_new_session"] = True
+        try:
+            self.process = subprocess.Popen(
+                command,
+                cwd=cwd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=self.log,
+                encoding="utf-8",
+                errors="strict",
+                text=True,
+                bufsize=1,
+                **options,
+            )
+        except BaseException:
+            self.log.close()
+            raise
+        if os.name == "nt":
+            from windows_job import WindowsJob
+
+            try:
+                self.job = WindowsJob(self.process.pid)
+            except BaseException:
+                self.process.kill()
+                self.process.wait(timeout=10)
+                self.process.stdin.close()
+                self.process.stdout.close()
+                self.log.close()
+                raise
+        self.reader = threading.Thread(target=self._read, daemon=True)
+        self.reader.start()
+
+    def _read(self) -> None:
+        try:
+            for line in self.process.stdout:
+                message = json.loads(line)
+                if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+                    raise ACPError("Grok returned an invalid JSON-RPC message")
+                self.messages.put(message)
+        except (ACPError, ValueError, OSError) as exc:
+            self.messages.put(ACPError(f"Could not read Grok ACP output: {exc}"))
+        finally:
+            self.messages.put(ACPError("Grok closed its ACP output; inspect grok.log"))
+
+    def send(self, message: dict[str, Any]) -> None:
+        try:
+            self.process.stdin.write(json.dumps({"jsonrpc": "2.0", **message}) + "\n")
+            self.process.stdin.flush()
+        except (BrokenPipeError, OSError, ValueError) as exc:
+            raise ACPError("Could not send to Grok; inspect grok.log") from exc
+
+    def request(self, method: str, params: dict[str, Any]) -> int:
+        self.next_id += 1
+        self.send({"id": self.next_id, "method": method, "params": params})
+        return self.next_id
+
+    def notify(self, method: str, params: dict[str, Any]) -> None:
+        self.send({"method": method, "params": params})
+
+    def receive(self, timeout: float = 0.1) -> dict[str, Any] | None:
+        try:
+            message = self.messages.get(timeout=timeout)
+        except queue.Empty:
+            return None
+        if isinstance(message, Exception):
+            raise message
+        return message
+
+    def close(self) -> None:
+        # Kill only this client's process tree, including tools still running
+        # after a stalled cancellation. Never target another Grok session.
+        if self.job is not None:
+            self.job.close()
+        else:
+            try:
+                os.killpg(self.process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        self.process.wait(timeout=10)
+        self.reader.join(timeout=2)
+        self.process.stdin.close()
+        self.process.stdout.close()
+        self.log.close()

--- a/skills/grok-cli/scripts/grok.py
+++ b/skills/grok-cli/scripts/grok.py
@@ -1,0 +1,733 @@
+#!/usr/bin/env python3
+"""Delegate background tasks to Grok Build over ACP. Requires Python 3.12+."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+import traceback
+import uuid
+from pathlib import Path
+from typing import Any
+
+from acp_client import ACPClient, ACPError
+
+FINISHED = {"completed", "cancelled", "failed", "timed_out"}
+HEARTBEAT_TIMEOUT = 15
+
+
+class TaskError(RuntimeError):
+    pass
+
+
+def encode(value: Any) -> str:
+    # ASCII escapes keep redirected JSON usable on non-UTF-8 Windows terminals.
+    return json.dumps(value, ensure_ascii=True, allow_nan=False)
+
+
+def default_state_dir() -> Path:
+    if os.name == "nt":
+        return (
+            Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData/Local"))
+            / "grok-acp"
+        )
+    return (
+        Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state"))
+        / "grok-acp"
+    )
+
+
+class Store:
+    def __init__(self, root: Path):
+        self.root = root.expanduser().resolve()
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.db = sqlite3.connect(self.root / "tasks.sqlite3", timeout=10)
+        self.db.execute("PRAGMA journal_mode=WAL")
+        self.db.executescript("""
+            CREATE TABLE IF NOT EXISTS tasks (
+                id TEXT PRIMARY KEY, config TEXT NOT NULL, state TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS commands (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL,
+                payload TEXT NOT NULL, result TEXT
+            );
+        """)
+
+    def close(self) -> None:
+        self.db.close()
+
+    def create(self, config: dict[str, Any]) -> dict[str, Any]:
+        task_id = uuid.uuid4().hex
+        directory = self.root / task_id
+        directory.mkdir(mode=0o700)
+        state = {
+            "task_id": task_id,
+            "session_id": None,
+            "status": "starting",
+            "closed": False,
+            "turn": 0,
+            "text": "",
+            "pending_permissions": [],
+            "tools": [],
+            "cwd": config["cwd"],
+            "updated_at": time.time(),
+            "log_dir": str(directory),
+        }
+        with self.db:
+            self.db.execute(
+                "INSERT INTO tasks VALUES (?, ?, ?)",
+                (task_id, encode(config), encode(state)),
+            )
+        return state
+
+    def get(self, task_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+        if len(task_id) != 32 or any(c not in "0123456789abcdef" for c in task_id):
+            raise TaskError("Invalid task ID; use the task_id returned by start")
+        row = self.db.execute(
+            "SELECT config, state FROM tasks WHERE id=?", (task_id,)
+        ).fetchone()
+        if row is None:
+            raise TaskError("Unknown task ID; use the same --state-dir as start")
+        return json.loads(row[0]), json.loads(row[1])
+
+    def save(self, state: dict[str, Any]) -> None:
+        state["updated_at"] = time.time()
+        with self.db:
+            self.db.execute(
+                "UPDATE tasks SET state=? WHERE id=?", (encode(state), state["task_id"])
+            )
+
+    def status(self, task_id: str) -> dict[str, Any]:
+        _, state = self.get(task_id)
+        if (
+            not state["closed"]
+            and time.time() - state["updated_at"] > HEARTBEAT_TIMEOUT
+        ):
+            state = {
+                **state,
+                "status": "unresponsive",
+                "error": "Worker heartbeat expired; inspect worker.log before starting another task",
+            }
+        return state
+
+    def submit(self, task_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        state = self.status(task_id)
+        if state["closed"] or state["status"] == "unresponsive":
+            raise TaskError(
+                "Task is closed or unresponsive; its recorded result remains available via status"
+            )
+        with self.db:
+            cursor = self.db.execute(
+                "INSERT INTO commands(task_id,payload) VALUES (?,?)",
+                (task_id, encode(payload)),
+            )
+            command_id = cursor.lastrowid
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            row = self.db.execute(
+                "SELECT result FROM commands WHERE id=?", (command_id,)
+            ).fetchone()
+            if row[0] is not None:
+                result = json.loads(row[0])
+                if "command_error" in result:
+                    raise TaskError(result["command_error"])
+                return {"command_id": command_id, **result}
+            time.sleep(0.05)
+        return {
+            "task_id": task_id,
+            "command_id": command_id,
+            "command_status": "queued",
+            "note": "Command not yet acknowledged; check status before retrying",
+        }
+
+    def commands(self, task_id: str) -> list[tuple[int, str]]:
+        return self.db.execute(
+            "SELECT id,payload FROM commands WHERE task_id=? AND result IS NULL ORDER BY id",
+            (task_id,),
+        ).fetchall()
+
+    def acknowledge(self, command_id: int, result: dict[str, Any]) -> None:
+        with self.db:
+            self.db.execute(
+                "UPDATE commands SET result=? WHERE id=?", (encode(result), command_id)
+            )
+
+
+class Worker:
+    def __init__(self, store: Store, task_id: str):
+        self.store = store
+        self.config, self.state = store.get(task_id)
+        self.directory = store.root / task_id
+        self.client: ACPClient | None = None
+        self.active_request: int | None = None
+        self.responses: dict[int, dict[str, Any]] = {}
+        self.permissions: dict[str, dict[str, Any]] = {}
+        self.turn_started = 0.0
+        self.idle_since = time.monotonic()
+        self.cancel_deadline: float | None = None
+        self.cancel_status = "cancelled"
+        self.closing = False
+        self.stop = False
+        self.last_save = 0.0
+
+    def save(self) -> None:
+        self.state["pending_permissions"] = list(self.permissions.values())
+        self.store.save(self.state)
+        self.last_save = time.monotonic()
+
+    def record(self, message: dict[str, Any]) -> None:
+        with (self.directory / "events.jsonl").open("a", encoding="utf-8") as stream:
+            stream.write(
+                encode({"time": time.time(), "turn": self.state["turn"], **message})
+                + "\n"
+            )
+
+    def rpc(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if self.stop:
+            raise TaskError("Task closed during initialization")
+        request_id = self.client.request(method, params)
+        deadline = time.monotonic() + self.config["startup_timeout"]
+        while request_id not in self.responses:
+            if self.stop:
+                raise TaskError("Task closed during initialization")
+            if time.monotonic() >= deadline:
+                raise TaskError(
+                    f"Grok did not answer {method} before --startup-timeout"
+                )
+            self.pump()
+        message = self.responses.pop(request_id)
+        if "error" in message:
+            error = message["error"]
+            raise ACPError(f"{method}: {error.get('message', error)}")
+        return message.get("result", {})
+
+    def initialize(self) -> None:
+        self.client = ACPClient(
+            self.config["command"], self.config["cwd"], self.directory / "grok.log"
+        )
+        self.state["grok_pid"] = self.client.process.pid
+        init = self.rpc(
+            "initialize",
+            {
+                "protocolVersion": 1,
+                "clientCapabilities": {},
+                "clientInfo": {"name": "grok-cli-skill", "version": "1"},
+            },
+        )
+        if init.get("protocolVersion") != 1:
+            raise TaskError("Grok negotiated an unsupported ACP protocol version")
+        self.state["agent_version"] = init.get("_meta", {}).get("agentVersion")
+        methods = {m["id"] for m in init.get("authMethods", [])}
+        method = init.get("_meta", {}).get("defaultAuthMethodId")
+        if method in {"cached_token", "xai.api_key"} and method in methods:
+            self.rpc("authenticate", {"methodId": method, "_meta": {"headless": True}})
+            self.state["auth_method"] = method
+        elif method in {"grok.com", "oidc"}:
+            raise TaskError(
+                "Grok requires interactive login; run grok login, then start a new task"
+            )
+        session = self.rpc("session/new", {"cwd": self.config["cwd"], "mcpServers": []})
+        self.state["session_id"] = session["sessionId"]
+        self.state["model"] = session.get("models", {}).get("currentModelId")
+        self.state["config_options"] = session.get("configOptions", [])
+        self.begin_turn(self.config["prompt"])
+
+    def begin_turn(self, prompt: str) -> None:
+        if self.stop:
+            raise TaskError("Task closed before the prompt was sent")
+        if self.active_request is not None:
+            raise TaskError(
+                "A turn is already running; wait or cancel it before replying"
+            )
+        self.state.update(
+            status="running", text="", tools=[], turn=self.state["turn"] + 1
+        )
+        for key in ("error", "stop_reason", "cancel_requested"):
+            self.state.pop(key, None)
+        self.cancel_deadline = None
+        self.cancel_status = "cancelled"
+        self.turn_started = time.monotonic()
+        self.record({"type": "prompt", "text": prompt})
+        self.active_request = self.client.request(
+            "session/prompt",
+            {
+                "sessionId": self.state["session_id"],
+                "prompt": [{"type": "text", "text": prompt}],
+            },
+        )
+        self.save()
+
+    def cancel(self, status: str = "cancelled") -> None:
+        if self.active_request is None:
+            raise TaskError("No active turn to cancel")
+        if self.cancel_deadline is not None:
+            return
+        self.cancel_status = status
+        for permission in self.permissions.values():
+            self.client.send(
+                {
+                    "id": permission["rpc_id"],
+                    "result": {"outcome": {"outcome": "cancelled"}},
+                }
+            )
+        self.permissions.clear()
+        self.client.notify("session/cancel", {"sessionId": self.state["session_id"]})
+        self.cancel_deadline = time.monotonic() + 10
+        self.state.update(status="cancelling", cancel_requested=True)
+        self.save()
+
+    def control(self, payload: dict[str, Any]) -> dict[str, Any]:
+        action = payload["action"]
+        if self.closing:
+            raise TaskError("Task is closing")
+        if action == "close":
+            self.closing = True
+            self.state["closing"] = True
+            if self.active_request is not None:
+                self.cancel()
+            else:
+                self.stop = True
+        elif action == "cancel":
+            if self.state["status"] == "starting":
+                self.state["status"] = "cancelled"
+                self.stop = True
+            else:
+                self.cancel()
+        elif action == "reply":
+            if self.state["status"] not in FINISHED:
+                raise TaskError("Wait for the current turn to finish before replying")
+            self.begin_turn(payload["prompt"])
+        elif action == "permission":
+            permission = self.permissions.get(payload["request_id"])
+            if permission is None:
+                raise TaskError("Permission request is no longer pending; check status")
+            options = {o["optionId"] for o in permission["options"]}
+            if payload["option_id"] not in options:
+                raise TaskError(
+                    "Unknown option ID; select an option from pending_permissions"
+                )
+            self.client.send(
+                {
+                    "id": permission["rpc_id"],
+                    "result": {
+                        "outcome": {
+                            "outcome": "selected",
+                            "optionId": payload["option_id"],
+                        }
+                    },
+                }
+            )
+            del self.permissions[payload["request_id"]]
+            self.state["status"] = "needs_approval" if self.permissions else "running"
+        else:
+            raise TaskError(f"Unknown worker command: {action}")
+        self.save()
+        return self.state.copy()
+
+    def handle(self, message: dict[str, Any]) -> None:
+        method = message.get("method")
+        if method is None:
+            if (
+                message.get("id") == self.active_request
+                and self.active_request is not None
+            ):
+                self.finish(message)
+            else:
+                self.responses[message.get("id")] = message
+            return
+        params = message.get("params", {})
+        if method == "session/request_permission" and "id" in message:
+            if (
+                params.get("sessionId") != self.state["session_id"]
+                or self.cancel_deadline is not None
+                or self.active_request is None
+            ):
+                self.client.send(
+                    {
+                        "id": message["id"],
+                        "result": {"outcome": {"outcome": "cancelled"}},
+                    }
+                )
+                return
+            request_id = str(message["id"])
+            self.permissions[request_id] = {
+                "request_id": request_id,
+                "rpc_id": message["id"],
+                "tool_call": params.get("toolCall", {}),
+                "options": params.get("options", []),
+            }
+            self.state["status"] = "needs_approval"
+            self.record(message)
+            self.save()
+        elif "id" in message:
+            # No filesystem or terminal callbacks are advertised. Grok owns
+            # execution; a new callback must be implemented before advertising it.
+            self.client.send(
+                {
+                    "id": message["id"],
+                    "error": {
+                        "code": -32601,
+                        "message": f"Client does not implement {method}",
+                    },
+                }
+            )
+        elif (
+            method == "session/update"
+            and params.get("sessionId") == self.state["session_id"]
+        ):
+            update = params.get("update", {})
+            kind = update.get("sessionUpdate")
+            if kind == "agent_message_chunk":
+                content = update.get("content", {})
+                if content.get("type") == "text":
+                    self.state["text"] += content.get("text", "")
+            elif kind in {"tool_call", "tool_call_update"}:
+                summary = {
+                    key: update[key]
+                    for key in ("toolCallId", "title", "kind", "status", "locations")
+                    if key in update
+                }
+                tools = self.state["tools"]
+                existing = next(
+                    (
+                        t
+                        for t in tools
+                        if t.get("toolCallId") == update.get("toolCallId")
+                    ),
+                    None,
+                )
+                if existing is None:
+                    tools.append(summary)
+                    del tools[:-10]
+                else:
+                    existing.update(summary)
+            elif kind == "config_option_update":
+                self.state["config_options"] = update.get("configOptions", [])
+                for option in self.state["config_options"]:
+                    if option.get("id") == "model":
+                        self.state["model"] = option.get("currentValue")
+            self.record(message)
+
+    def finish(self, message: dict[str, Any]) -> None:
+        self.active_request = None
+        self.permissions.clear()
+        self.idle_since = time.monotonic()
+        self.record({"type": "turn_result", "response": message})
+        if "error" in message:
+            self.state.update(status="failed", error=message["error"])
+        else:
+            reason = message.get("result", {}).get("stopReason")
+            status = (
+                "completed"
+                if reason == "end_turn"
+                else "cancelled"
+                if reason == "cancelled"
+                else "failed"
+            )
+            self.state.update(status=status, stop_reason=reason)
+            if status == "failed":
+                self.state["error"] = (
+                    f"Grok stopped with {reason!r}; inspect the partial result before retrying"
+                )
+        if self.cancel_deadline is not None and self.cancel_status == "timed_out":
+            self.state.update(
+                status="timed_out",
+                error="Turn exceeded --turn-timeout and was cancelled",
+            )
+        self.cancel_deadline = None
+        if self.closing:
+            self.stop = True
+        self.save()
+
+    def pump(self) -> None:
+        for command_id, raw in self.store.commands(self.state["task_id"]):
+            try:
+                result = self.control(json.loads(raw))
+            except TaskError as exc:
+                result = {"command_error": str(exc)}
+            self.store.acknowledge(command_id, result)
+        if self.stop:
+            return
+        message = self.client.receive()
+        if message is not None:
+            self.handle(message)
+        now = time.monotonic()
+        if (
+            self.active_request is not None
+            and now - self.turn_started > self.config["turn_timeout"]
+        ):
+            self.cancel("timed_out")
+        if self.cancel_deadline is not None and now >= self.cancel_deadline:
+            self.state.update(
+                status=self.cancel_status,
+                stop_reason="forced_stop",
+                error="Grok did not acknowledge cancellation; its process tree was stopped",
+            )
+            self.stop = True
+        if now - self.last_save >= 1:
+            self.save()
+
+    def run(self) -> None:
+        self.state["worker_pid"] = os.getpid()
+        self.save()
+        try:
+            self.initialize()
+            while not self.stop:
+                self.pump()
+                if (
+                    self.active_request is None
+                    and time.monotonic() - self.idle_since
+                    >= self.config["idle_timeout"]
+                ):
+                    self.state["close_reason"] = "idle_timeout"
+                    break
+        except Exception as exc:
+            traceback.print_exc()
+            if self.state["status"] != "cancelled":
+                self.state.update(status="failed", error=str(exc))
+            raise
+        finally:
+            try:
+                if self.client is not None:
+                    self.client.close()
+            finally:
+                self.permissions.clear()
+                self.state["closed"] = True
+                self.state["closing"] = False
+                self.save()
+
+
+def launch(store: Store, config: dict[str, Any]) -> dict[str, Any]:
+    state = store.create(config)
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--state-dir",
+        str(store.root),
+        "--worker",
+        state["task_id"],
+    ]
+    options: dict[str, Any] = {}
+    if os.name == "nt":
+        options["creationflags"] = (
+            subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+    else:
+        options["start_new_session"] = True
+    try:
+        with (store.root / state["task_id"] / "worker.log").open("ab") as log:
+            process = subprocess.Popen(
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=log,
+                cwd=store.root,
+                close_fds=True,
+                **options,
+            )
+        # Retain no inherited pipes: a caller can exit while the worker lives.
+        threading.Thread(target=process.wait, daemon=True).start()
+        return {**state, "worker_pid": process.pid}
+    except OSError as exc:
+        state.update(status="failed", closed=True, error=str(exc))
+        store.save(state)
+        raise
+
+
+def read_prompt(args: argparse.Namespace) -> str:
+    if args.prompt_file is not None:
+        text = args.prompt_file.read_text(encoding="utf-8-sig")
+    elif args.prompt is not None:
+        text = args.prompt
+    else:
+        text = sys.stdin.buffer.read().decode("utf-8-sig")
+    if not text.strip():
+        raise TaskError(
+            "Prompt is empty; provide --prompt, --prompt-file, or UTF-8 stdin"
+        )
+    return text
+
+
+def seconds(value: str) -> float:
+    number = float(value)
+    if not math.isfinite(number) or number <= 0:
+        raise argparse.ArgumentTypeError(
+            "timeout must be a finite number greater than zero"
+        )
+    return number
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    root.add_argument(
+        "--state-dir",
+        type=Path,
+        default=default_state_dir(),
+        help="task storage directory (reuse it across commands)",
+    )
+    root.add_argument("--worker", help=argparse.SUPPRESS)
+    sub = root.add_subparsers(dest="action")
+    start = sub.add_parser(
+        "start", help="start a background Grok session and return its task ID"
+    )
+    start.add_argument(
+        "--cwd", type=Path, required=True, help="working directory for Grok"
+    )
+    start.add_argument("--grok", default="grok", help="Grok executable name or path")
+    start.add_argument("--model", help="override model for this task only")
+    start.add_argument("--effort", help="override reasoning effort for this task only")
+    start.add_argument(
+        "--permission-mode",
+        choices=[
+            "default",
+            "acceptEdits",
+            "auto",
+            "dontAsk",
+            "bypassPermissions",
+            "plan",
+        ],
+        help="explicit Grok permission override; otherwise inherit configuration",
+    )
+    start.add_argument(
+        "--sandbox",
+        help="explicit Grok sandbox profile; otherwise inherit configuration",
+    )
+    start.add_argument(
+        "--startup-timeout",
+        type=seconds,
+        default=30,
+        help="seconds allowed per ACP setup request",
+    )
+    start.add_argument(
+        "--turn-timeout",
+        type=seconds,
+        default=900,
+        help="seconds per turn before requesting cancellation",
+    )
+    start.add_argument(
+        "--idle-timeout",
+        type=seconds,
+        default=1800,
+        help="seconds to keep a completed session open for replies",
+    )
+    reply = sub.add_parser(
+        "reply", help="send another prompt to an open, finished task"
+    )
+    for item in (start, reply):
+        prompts = item.add_mutually_exclusive_group()
+        prompts.add_argument(
+            "--prompt", help="task text; defaults to reading UTF-8 stdin"
+        )
+        prompts.add_argument(
+            "--prompt-file", type=Path, help="UTF-8 file containing task text"
+        )
+    reply.add_argument("task_id")
+    for name, help_text in [
+        ("status", "read the latest state and response"),
+        ("wait", "wait for a result or permission request"),
+        ("cancel", "cancel the current turn; keep the session if Grok acknowledges"),
+        ("close", "cancel active work and release the session"),
+        ("permission", "answer one pending permission request"),
+    ]:
+        item = sub.add_parser(name, help=help_text)
+        item.add_argument("task_id")
+        if name == "wait":
+            item.add_argument(
+                "--timeout",
+                type=seconds,
+                default=30,
+                help="maximum seconds to wait; does not cancel Grok",
+            )
+        if name == "permission":
+            item.add_argument("--request-id", required=True)
+            item.add_argument("--option-id", required=True)
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    cli = parser()
+    args = cli.parse_args(argv)
+    if not args.action and not args.worker:
+        cli.error("a command is required")
+    store: Store | None = None
+    try:
+        store = Store(args.state_dir)
+        if args.worker:
+            Worker(store, args.worker).run()
+            return 0
+        if args.action == "start":
+            cwd = args.cwd.expanduser().resolve(strict=True)
+            if not cwd.is_dir():
+                raise TaskError("--cwd must be a directory")
+            grok = shutil.which(args.grok)
+            if grok is None:
+                raise TaskError(
+                    "Grok Build executable not found; install Grok or pass --grok with its path"
+                )
+            command = [str(Path(grok).resolve())]
+            for key, flag in [
+                ("permission_mode", "--permission-mode"),
+                ("sandbox", "--sandbox"),
+            ]:
+                if getattr(args, key):
+                    command.extend([flag, getattr(args, key)])
+            command.extend(["agent", "--no-leader"])
+            for key, flag in [("model", "--model"), ("effort", "--reasoning-effort")]:
+                if getattr(args, key):
+                    command.extend([flag, getattr(args, key)])
+            command.append("stdio")
+            result = launch(
+                store,
+                {
+                    "cwd": str(cwd),
+                    "command": command,
+                    "prompt": read_prompt(args),
+                    "startup_timeout": args.startup_timeout,
+                    "turn_timeout": args.turn_timeout,
+                    "idle_timeout": args.idle_timeout,
+                },
+            )
+        elif args.action in {"status", "wait"}:
+            deadline = time.monotonic() + (args.timeout if args.action == "wait" else 0)
+            while True:
+                result = store.status(args.task_id)
+                if (
+                    result["closed"]
+                    or (
+                        not result.get("closing")
+                        and result["status"]
+                        in FINISHED | {"needs_approval", "unresponsive"}
+                    )
+                    or time.monotonic() >= deadline
+                ):
+                    break
+                time.sleep(0.1)
+        else:
+            payload = {"action": args.action}
+            if args.action == "reply":
+                payload["prompt"] = read_prompt(args)
+            elif args.action == "permission":
+                payload.update(request_id=args.request_id, option_id=args.option_id)
+            result = store.submit(args.task_id, payload)
+        print(encode(result))
+        return (
+            1 if result.get("status") in {"failed", "timed_out", "unresponsive"} else 0
+        )
+    except (TaskError, OSError, ValueError, sqlite3.Error) as exc:
+        print(encode({"error": str(exc)}))
+        return 1
+    finally:
+        if store is not None:
+            store.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/grok-cli/scripts/windows_job.py
+++ b/skills/grok-cli/scripts/windows_job.py
@@ -1,0 +1,83 @@
+"""Keep a Grok process tree tied to its worker's lifetime on Windows."""
+
+import ctypes
+from ctypes import wintypes
+
+
+class BasicLimits(ctypes.Structure):
+    _fields_ = [
+        ("process_time", ctypes.c_int64),
+        ("job_time", ctypes.c_int64),
+        ("flags", wintypes.DWORD),
+        ("min_working_set", ctypes.c_size_t),
+        ("max_working_set", ctypes.c_size_t),
+        ("active_processes", wintypes.DWORD),
+        ("affinity", ctypes.c_size_t),
+        ("priority", wintypes.DWORD),
+        ("scheduling", wintypes.DWORD),
+    ]
+
+
+class ExtendedLimits(ctypes.Structure):
+    _fields_ = [
+        ("basic", BasicLimits),
+        ("io_counters", ctypes.c_uint64 * 6),
+        ("process_memory", ctypes.c_size_t),
+        ("job_memory", ctypes.c_size_t),
+        ("peak_process_memory", ctypes.c_size_t),
+        ("peak_job_memory", ctypes.c_size_t),
+    ]
+
+
+class WindowsJob:
+    def __init__(self, pid: int):
+        self.kernel = ctypes.WinDLL("kernel32", use_last_error=True)
+        signatures = {
+            "CreateJobObjectW": ([ctypes.c_void_p, wintypes.LPCWSTR], wintypes.HANDLE),
+            "SetInformationJobObject": (
+                [wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD],
+                wintypes.BOOL,
+            ),
+            "OpenProcess": (
+                [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD],
+                wintypes.HANDLE,
+            ),
+            "AssignProcessToJobObject": (
+                [wintypes.HANDLE, wintypes.HANDLE],
+                wintypes.BOOL,
+            ),
+            "CloseHandle": ([wintypes.HANDLE], wintypes.BOOL),
+        }
+        for name, (args, result) in signatures.items():
+            function = getattr(self.kernel, name)
+            function.argtypes = args
+            function.restype = result
+        self.handle = self.kernel.CreateJobObjectW(None, None)
+        if not self.handle:
+            raise ctypes.WinError(ctypes.get_last_error())
+        try:
+            limits = ExtendedLimits()
+            limits.basic.flags = 0x2000  # JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            if not self.kernel.SetInformationJobObject(
+                self.handle, 9, ctypes.byref(limits), ctypes.sizeof(limits)
+            ):
+                raise ctypes.WinError(ctypes.get_last_error())
+            process = self.kernel.OpenProcess(
+                0x0101, False, pid
+            )  # SET_QUOTA | TERMINATE
+            if not process:
+                raise ctypes.WinError(ctypes.get_last_error())
+            try:
+                if not self.kernel.AssignProcessToJobObject(self.handle, process):
+                    raise ctypes.WinError(ctypes.get_last_error())
+            finally:
+                self.kernel.CloseHandle(process)
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self):
+        if self.handle:
+            if not self.kernel.CloseHandle(self.handle):
+                raise ctypes.WinError(ctypes.get_last_error())
+            self.handle = None

--- a/tests/fixtures/grok_acp_agent.py
+++ b/tests/fixtures/grok_acp_agent.py
@@ -1,0 +1,154 @@
+"""Offline ACP peer used by the Grok skill's subprocess tests."""
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+if sys.argv[1] == "--child":
+    marker = Path(sys.argv[2])
+    while True:
+        marker.write_text(str(time.monotonic()), encoding="utf-8")
+        time.sleep(0.03)
+
+trace = Path(sys.argv[1])
+mode = sys.argv[2] if len(sys.argv) > 2 else "normal"
+session_id = "test-session"
+active = None
+permissions = set()
+turns = 0
+
+
+def send(**message):
+    print(json.dumps({"jsonrpc": "2.0", **message}), flush=True)
+
+
+def update(session_update, **values):
+    send(
+        method="session/update",
+        params={
+            "sessionId": session_id,
+            "update": {"sessionUpdate": session_update, **values},
+        },
+    )
+
+
+def complete(text):
+    global active
+    update("agent_message_chunk", content={"type": "text", "text": text[:2]})
+    update("agent_message_chunk", content={"type": "text", "text": text[2:]})
+    send(id=active, result={"stopReason": "end_turn"})
+    active = None
+
+
+for line in sys.stdin:
+    message = json.loads(line)
+    with trace.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(message) + "\n")
+    method = message.get("method")
+    params = message.get("params", {})
+    request_id = message.get("id")
+    if method == "initialize":
+        if mode == "startup_hang":
+            continue
+        send(
+            id=request_id,
+            result={
+                "protocolVersion": 99 if mode == "bad_version" else 1,
+                "authMethods": [{"id": "cached_token"}, {"id": "xai.api_key"}],
+                "_meta": {"defaultAuthMethodId": "cached_token"},
+            },
+        )
+    elif method == "authenticate":
+        if mode == "authfail":
+            send(id=request_id, error={"code": -32000, "message": "Login expired"})
+        else:
+            send(id=request_id, result={})
+    elif method == "session/new":
+        send(
+            id=request_id,
+            result={
+                "sessionId": session_id,
+                "models": {"currentModelId": "configured-model"},
+            },
+        )
+    elif method == "session/prompt":
+        assert params["sessionId"] == session_id
+        active = request_id
+        turns += 1
+        prompt = params["prompt"][0]["text"]
+        if prompt == "hold":
+            update(
+                "tool_call",
+                toolCallId="t1",
+                title="Waiting",
+                kind="read",
+                status="in_progress",
+            )
+        elif prompt == "permission":
+            permissions = {801, 802}
+            for permission_id in sorted(permissions):
+                send(
+                    id=permission_id,
+                    method="session/request_permission",
+                    params={
+                        "sessionId": session_id,
+                        "toolCall": {
+                            "toolCallId": str(permission_id),
+                            "title": "Read file",
+                            "kind": "read",
+                        },
+                        "options": [
+                            {
+                                "optionId": "yes",
+                                "kind": "allow_once",
+                                "name": "Allow once",
+                            },
+                            {"optionId": "no", "kind": "reject_once", "name": "Reject"},
+                        ],
+                    },
+                )
+        elif prompt == "unsupported":
+            send(
+                id=900,
+                method="fs/read_text_file",
+                params={"sessionId": session_id, "path": "/unused"},
+            )
+        elif prompt == "error":
+            send(id=request_id, error={"code": -32000, "message": "Provider failed"})
+            active = None
+        elif prompt == "limit":
+            update("agent_message_chunk", content={"type": "text", "text": "partial"})
+            send(id=request_id, result={"stopReason": "max_tokens"})
+            active = None
+        elif prompt == "exit":
+            sys.exit(7)
+        elif prompt == "child_exit":
+            marker = trace.with_suffix(".child")
+            child = subprocess.Popen(
+                [sys.executable, __file__, "--child", str(marker)],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            deadline = time.monotonic() + 3
+            while not marker.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            sys.exit(7)
+        elif prompt == "bad_json":
+            print("not JSON", flush=True)
+        else:
+            complete(f"turn {turns}: {prompt}")
+    elif method == "session/cancel":
+        if mode != "ignore_cancel":
+            send(id=active, result={"stopReason": "cancelled"})
+            active = None
+            permissions.clear()
+    elif method is None and request_id in permissions:
+        if message.get("result", {}).get("outcome", {}).get("outcome") == "selected":
+            permissions.remove(request_id)
+            if not permissions:
+                complete("permissions handled")
+    elif method is None and request_id == 900:
+        complete("unsupported callback: " + str(message.get("error", {}).get("code")))

--- a/tests/test_grok_acp.py
+++ b/tests/test_grok_acp.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "skills/grok-cli/scripts/grok.py"
+FIXTURE = ROOT / "tests/fixtures/grok_acp_agent.py"
+sys.path.insert(0, str(SCRIPT.parent))
+spec = importlib.util.spec_from_file_location("grok_task_runner", SCRIPT)
+grok = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(grok)
+
+
+class GrokTaskTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.store = grok.Store(self.root / "state")
+        self.tasks = []
+
+    def tearDown(self):
+        for task_id in self.tasks:
+            state = self.store.status(task_id)
+            if not state["closed"]:
+                self.store.submit(task_id, {"action": "close"})
+                self.until(task_id, lambda s: s["closed"], timeout=20)
+        self.store.close()
+        # The worker publishes its final state immediately before interpreter exit.
+        for attempt in range(40):
+            try:
+                self.temp.cleanup()
+                break
+            except PermissionError:
+                if attempt == 39:
+                    raise
+                time.sleep(0.05)
+
+    def start(self, prompt="hello", mode="normal", **kwargs):
+        config = {
+            "cwd": str(self.root),
+            "command": [
+                sys.executable,
+                str(FIXTURE),
+                str(self.root / "trace.jsonl"),
+                mode,
+            ],
+            "prompt": prompt,
+            "startup_timeout": 3,
+            "turn_timeout": 30,
+            "idle_timeout": 60,
+            **kwargs,
+        }
+        state = grok.launch(self.store, config)
+        self.tasks.append(state["task_id"])
+        return state["task_id"]
+
+    def until(self, task_id, predicate, timeout=10):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            state = self.store.status(task_id)
+            if predicate(state):
+                return state
+            time.sleep(0.05)
+        self.fail(f"Timed out: {state}")
+
+    def finished(self, task_id):
+        return self.until(task_id, lambda s: s["status"] in grok.FINISHED)
+
+    def trace(self):
+        return [
+            json.loads(line)
+            for line in (self.root / "trace.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        ]
+
+    def cli(self, *args):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--state-dir", str(self.store.root), *args],
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        return result, json.loads(result.stdout)
+
+    def test_background_task_streams_unicode_and_reuses_session(self):
+        task = self.start("你好\nquoted ` $() text")
+        first = self.finished(task)
+        self.assertEqual(first["text"], "turn 1: 你好\nquoted ` $() text")
+        self.assertFalse(first["closed"])
+        reply = self.store.submit(task, {"action": "reply", "prompt": "follow-up"})
+        self.assertEqual(reply["turn"], 2)
+        second = self.finished(task)
+        self.assertEqual(second["session_id"], first["session_id"])
+        self.assertEqual(second["text"], "turn 2: follow-up")
+        trace = self.trace()
+        self.assertEqual(sum(m.get("method") == "session/new" for m in trace), 1)
+        self.assertEqual(trace[0]["params"]["clientCapabilities"], {})
+        auth = next(m for m in trace if m.get("method") == "authenticate")
+        self.assertEqual(auth["params"]["methodId"], "cached_token")
+        self.assertEqual(auth["params"]["_meta"], {"headless": True})
+
+    def test_permission_options_are_validated_and_all_requests_handled(self):
+        task = self.start("permission")
+        state = self.until(task, lambda s: len(s["pending_permissions"]) == 2)
+        self.assertEqual(state["status"], "needs_approval")
+        with self.assertRaises(grok.TaskError):
+            self.store.submit(
+                task,
+                {"action": "permission", "request_id": "801", "option_id": "invented"},
+            )
+        self.store.submit(
+            task, {"action": "permission", "request_id": "801", "option_id": "yes"}
+        )
+        self.assertEqual(self.store.status(task)["status"], "needs_approval")
+        with self.assertRaises(grok.TaskError):
+            self.store.submit(
+                task, {"action": "permission", "request_id": "801", "option_id": "yes"}
+            )
+        self.store.submit(
+            task, {"action": "permission", "request_id": "802", "option_id": "no"}
+        )
+        state = self.finished(task)
+        self.assertEqual(state["text"], "permissions handled")
+        self.assertFalse(state["pending_permissions"])
+
+    def test_cancel_resolves_permissions_and_allows_followup(self):
+        task = self.start("permission")
+        self.until(task, lambda s: len(s["pending_permissions"]) == 2)
+        self.store.submit(task, {"action": "cancel"})
+        state = self.finished(task)
+        self.assertEqual(state["status"], "cancelled")
+        self.assertFalse(state["closed"])
+        outcomes = [
+            m["result"]["outcome"]["outcome"]
+            for m in self.trace()
+            if m.get("id") in {801, 802}
+        ]
+        self.assertEqual(outcomes, ["cancelled", "cancelled"])
+        self.store.submit(task, {"action": "reply", "prompt": "after cancellation"})
+        self.assertEqual(self.finished(task)["text"], "turn 2: after cancellation")
+
+    def test_wait_timeout_does_not_cancel_and_running_reply_is_rejected(self):
+        task = self.start("hold")
+        self.until(task, lambda s: s["status"] == "running")
+        result, state = self.cli("wait", task, "--timeout", "0.2")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(state["status"], "running")
+        with self.assertRaises(grok.TaskError):
+            self.store.submit(task, {"action": "reply", "prompt": "overlap"})
+        self.assertFalse(any(m.get("method") == "session/cancel" for m in self.trace()))
+
+    def test_turn_deadline_cancels_instead_of_claiming_completion(self):
+        task = self.start("hold", turn_timeout=0.2)
+        state = self.finished(task)
+        self.assertEqual(state["status"], "timed_out")
+        self.assertEqual(state["stop_reason"], "cancelled")
+        result, _ = self.cli("status", task)
+        self.assertEqual(result.returncode, 1)
+
+    def test_unacknowledged_cancel_closes_process_and_preserves_reason(self):
+        task = self.start("hold", mode="ignore_cancel")
+        self.until(task, lambda s: s["status"] == "running")
+        self.store.submit(task, {"action": "cancel"})
+        state = self.until(task, lambda s: s["closed"], timeout=15)
+        self.assertEqual(state["status"], "cancelled")
+        self.assertEqual(state["stop_reason"], "forced_stop")
+
+    def test_close_active_task_cancels_and_retains_result(self):
+        task = self.start("hold")
+        self.until(task, lambda s: s["status"] == "running")
+        self.store.submit(task, {"action": "close"})
+        state = self.until(task, lambda s: s["closed"])
+        self.assertEqual(state["status"], "cancelled")
+        with self.assertRaises(grok.TaskError):
+            self.store.submit(task, {"action": "reply", "prompt": "closed"})
+
+    def test_idle_timeout_closes_without_losing_completed_text(self):
+        task = self.start(idle_timeout=0.2)
+        state = self.until(task, lambda s: s["closed"])
+        self.assertEqual(state["status"], "completed")
+        self.assertEqual(state["text"], "turn 1: hello")
+        self.assertEqual(state["close_reason"], "idle_timeout")
+
+    def test_provider_error_is_visible_and_same_session_can_be_retried(self):
+        task = self.start("error")
+        state = self.finished(task)
+        self.assertEqual(state["error"]["message"], "Provider failed")
+        self.store.submit(task, {"action": "reply", "prompt": "retry"})
+        state = self.finished(task)
+        self.assertEqual(state["status"], "completed")
+        self.assertNotIn("error", state)
+
+    def test_non_end_turn_stop_reason_is_incomplete_with_partial_text(self):
+        task = self.start("limit")
+        state = self.finished(task)
+        self.assertEqual(state["status"], "failed")
+        self.assertEqual(state["stop_reason"], "max_tokens")
+        self.assertEqual(state["text"], "partial")
+
+    def test_protocol_and_process_failures_close_task(self):
+        for prompt in ("exit", "bad_json"):
+            with self.subTest(prompt=prompt):
+                task = self.start(prompt)
+                state = self.until(task, lambda s: s["closed"])
+                self.assertEqual(state["status"], "failed")
+                self.assertTrue(state["error"])
+
+    def test_agent_exit_does_not_leave_its_tool_process_running(self):
+        task = self.start("child_exit")
+        self.until(task, lambda s: s["closed"])
+        marker = self.root / "trace.child"
+        self.assertTrue(marker.exists())
+        previous = marker.read_bytes()
+        time.sleep(0.2)
+        self.assertEqual(marker.read_bytes(), previous)
+
+    def test_setup_failures_never_send_prompt_or_change_auth_method(self):
+        for mode in ("authfail", "bad_version", "startup_hang"):
+            with self.subTest(mode=mode):
+                (self.root / "trace.jsonl").unlink(missing_ok=True)
+                task = self.start(mode=mode, startup_timeout=0.3)
+                state = self.until(task, lambda s: s["closed"])
+                self.assertEqual(state["status"], "failed")
+                self.assertEqual(state["turn"], 0)
+                trace = self.trace()
+                self.assertFalse(
+                    any(m.get("method") == "session/prompt" for m in trace)
+                )
+                self.assertFalse(
+                    any(
+                        m.get("params", {}).get("methodId") == "xai.api_key"
+                        for m in trace
+                    )
+                )
+
+    def test_startup_can_be_cancelled_without_sending_prompt(self):
+        task = self.start(mode="startup_hang", startup_timeout=15)
+        self.until(task, lambda s: "grok_pid" in s)
+        self.store.submit(task, {"action": "cancel"})
+        state = self.until(task, lambda s: s["closed"])
+        self.assertEqual(state["status"], "cancelled")
+        self.assertFalse(any(m.get("method") == "session/prompt" for m in self.trace()))
+
+    def test_unsupported_client_request_returns_method_not_found(self):
+        task = self.start("unsupported")
+        self.assertEqual(self.finished(task)["text"], "unsupported callback: -32601")
+
+    def test_stale_heartbeat_is_not_reported_as_live_work(self):
+        state = self.store.create({"cwd": str(self.root)})
+        state["updated_at"] -= 60
+        with self.store.db:
+            self.store.db.execute(
+                "UPDATE tasks SET state=? WHERE id=?",
+                (json.dumps(state), state["task_id"]),
+            )
+        self.assertEqual(self.store.status(state["task_id"])["status"], "unresponsive")
+        with self.assertRaises(grok.TaskError):
+            self.store.submit(
+                state["task_id"], {"action": "reply", "prompt": "duplicate"}
+            )
+
+    def test_cli_uses_argument_array_and_inherits_unspecified_options(self):
+        prompt = self.root / "task.txt"
+        prompt.write_text("你好 $() `quoted`", encoding="utf-8-sig")
+        output = io.StringIO()
+        with (
+            patch.object(grok, "launch", return_value={"status": "starting"}) as launch,
+            patch.object(grok.shutil, "which", return_value=sys.executable),
+            contextlib.redirect_stdout(output),
+        ):
+            code = grok.main(
+                [
+                    "--state-dir",
+                    str(self.store.root),
+                    "start",
+                    "--cwd",
+                    str(self.root),
+                    "--prompt-file",
+                    str(prompt),
+                ]
+            )
+        self.assertEqual(code, 0)
+        config = launch.call_args.args[1]
+        self.assertEqual(
+            config["command"],
+            [str(Path(sys.executable).resolve()), "agent", "--no-leader", "stdio"],
+        )
+        self.assertEqual(config["prompt"], "你好 $() `quoted`")
+        self.assertEqual(json.loads(output.getvalue()), {"status": "starting"})
+
+    def test_cli_overrides_are_scoped_and_in_correct_argument_positions(self):
+        with (
+            patch.object(grok, "launch", return_value={}) as launch,
+            patch.object(grok.shutil, "which", return_value=sys.executable),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            grok.main(
+                [
+                    "--state-dir",
+                    str(self.store.root),
+                    "start",
+                    "--cwd",
+                    str(self.root),
+                    "--prompt",
+                    "test",
+                    "--model",
+                    "chosen",
+                    "--effort",
+                    "high",
+                    "--permission-mode",
+                    "default",
+                    "--sandbox",
+                    "workspace",
+                ]
+            )
+        self.assertEqual(
+            launch.call_args.args[1]["command"][1:],
+            [
+                "--permission-mode",
+                "default",
+                "--sandbox",
+                "workspace",
+                "agent",
+                "--no-leader",
+                "--model",
+                "chosen",
+                "--reasoning-effort",
+                "high",
+                "stdio",
+            ],
+        )
+
+    def test_cli_rejects_missing_binary_bad_task_id_empty_prompt_and_timeout(self):
+        result, body = self.cli(
+            "start",
+            "--cwd",
+            str(self.root),
+            "--grok",
+            "grok-does-not-exist",
+            "--prompt",
+            "test",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("error", body)
+        with self.assertRaises(grok.TaskError):
+            self.store.status("../outside")
+        with self.assertRaises(grok.TaskError):
+            grok.read_prompt(
+                grok.parser().parse_args(["reply", "0" * 32, "--prompt", " "])
+            )
+        for value in ("0", "-1", "nan", "inf"):
+            with self.assertRaises(argparse.ArgumentTypeError):
+                grok.seconds(value)
+
+    def test_json_stdout_roundtrips_under_ascii_encoding(self):
+        task = self.start("中文")
+        self.finished(task)
+        env = {**os.environ, "PYTHONIOENCODING": "ascii"}
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--state-dir",
+                str(self.store.root),
+                "status",
+                task,
+            ],
+            capture_output=True,
+            env=env,
+            timeout=10,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["text"], "turn 1: 中文")
+        self.assertEqual(result.stderr, b"")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a `grok-cli` skill that lets a supervising agent delegate work to the installed Grok Build CLI over ACP. Starting a task immediately returns an ID; the supervisor can continue independent work, inspect progress, wait, send follow-up prompts to the same session, handle permissions, cancel, and close the task. The skill explains task boundaries, effort selection, explicit reporting of unavailable or failed Grok tasks, and result verification.

The bundled Python 3.12+ client uses only the standard library and inherits Grok configuration unless the caller supplies a per-task override. Its new CLI returns JSON task state, including `task_id`, `session_id`, `status`, and `closed`, with local state and diagnostic logs. It handles protocol and provider errors, pending permissions, turn and idle timeouts, and process cleanup. Windows uses a job object to clean up Grok and its tool processes. Add offline integration coverage and a Windows CI job; the existing Linux job runs the full suite.

## Validation

- `uv run --python 3.12 -m unittest discover -s tests -p test_grok_acp.py -v` — 20 tests passed, covering conversation reuse, interleaved permission requests, cancellation, timeouts, process failure and cleanup, and Windows JSON encoding.
- `uv tool run ruff check skills/grok-cli/scripts tests/test_grok_acp.py tests/fixtures/grok_acp_agent.py` — passed.
- `uv run --python 3.12 scripts/update_readme_skills.py --check`, the skill-creator validator, `gh skill publish --dry-run`, and `git diff --check` — passed.
- Packaged the skill with `scripts/package_skill.py` into a temporary output directory.
- Real Windows Grok checks: multi-turn chat, file reading and writing after a single-use permission approval, cancellation, and session cleanup.
- A fresh Codex task used only the skill, its referenced documentation, and `--help` to complete four chat turns with contextual recall. It then started a separate Grok session to write an SVG while Codex independently prepared display notes and reported progress. The SVG passed XML and self-containment checks, was rendered and inspected, and the session was closed.

CLI help output:

```text
usage: grok.py [-h] [--state-dir STATE_DIR]
               {start,reply,status,wait,cancel,close,permission} ...

Delegate background tasks to Grok Build over ACP. Requires Python 3.12+.
```
