### PR TITLE
ci: consolidate validation in the Ubuntu job

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Test catalog generator
+      - name: Run test suite
         run: python -m unittest discover -s tests -v
 
       - name: Check README skill catalog
@@ -31,17 +31,3 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh skill publish --dry-run
-
-  grok-windows:
-    runs-on: windows-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Test Grok ACP client on Windows
-        run: python -m unittest discover -s tests -p test_grok_acp.py -v


### PR DESCRIPTION
Run all validation in the existing `ubuntu-24.04` job: the full unittest suite (including Grok ACP tests), README catalog verification, and skill validation. Remove the separate Windows job and rename the test step to reflect its full-suite coverage.

Validation: parsed the workflow YAML and confirmed that the single Ubuntu job retains full test discovery; `git diff --check` passes.
